### PR TITLE
Add darwin/macOS/OS X support.

### DIFF
--- a/mpiPi.h.in
+++ b/mpiPi.h.in
@@ -1,10 +1,10 @@
-/* -*- C -*- 
+/* -*- C -*-
 
    mpiP MPI Profiler ( http://llnl.github.io/mpiP )
 
    Please see COPYRIGHT AND LICENSE information at the end of this file.
 
-   ----- 
+   -----
 
    mpiPi.h -- internal mpiP header
 
@@ -16,7 +16,6 @@
 #define _MPIPI_H
 
 #include <assert.h>
-#include <malloc.h>
 #include <math.h>
 #include <setjmp.h>
 #include <stdio.h>
@@ -340,14 +339,14 @@ extern void *saved_ret_addr;
 /*
  * Unlike some of the other platforms, we do not use setjmp to obtain
  * the frame pointer of the current function.  Instead, we use the
- * Cray intrinsic function _read_fp() to get the frame pointer of the 
+ * Cray intrinsic function _read_fp() to get the frame pointer of the
  * current function.
  */
 #define GetFP()    ((void*)(_read_fp()))
 
 
-/* 
- * Given a frame pointer for a callee, the caller's frame pointer is at the 
+/*
+ * Given a frame pointer for a callee, the caller's frame pointer is at the
  * callee's frame pointer address.
  */
 #define NextFP(fp)      ((void*)((void**)fp)[0])
@@ -373,33 +372,33 @@ extern void *saved_ret_addr;
 #endif
 
 /*
-  
+
   <license>
-  
-  Copyright (c) 2006, The Regents of the University of California. 
-  Produced at the Lawrence Livermore National Laboratory 
-  Written by Jeffery Vetter and Christopher Chambreau. 
-  UCRL-CODE-223450. 
-  All rights reserved. 
-   
-  This file is part of mpiP.  For details, see http://llnl.github.io/mpiP. 
-   
+
+  Copyright (c) 2006, The Regents of the University of California.
+  Produced at the Lawrence Livermore National Laboratory
+  Written by Jeffery Vetter and Christopher Chambreau.
+  UCRL-CODE-223450.
+  All rights reserved.
+
+  This file is part of mpiP.  For details, see http://llnl.github.io/mpiP.
+
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are
   met:
-   
+
   * Redistributions of source code must retain the above copyright
   notice, this list of conditions and the disclaimer below.
-  
+
   * Redistributions in binary form must reproduce the above copyright
   notice, this list of conditions and the disclaimer (as noted below) in
   the documentation and/or other materials provided with the
   distribution.
-  
+
   * Neither the name of the UC/LLNL nor the names of its contributors
   may be used to endorse or promote products derived from this software
   without specific prior written permission.
-  
+
   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -412,22 +411,22 @@ extern void *saved_ret_addr;
   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-   
-   
-  Additional BSD Notice 
-   
+
+
+  Additional BSD Notice
+
   1. This notice is required to be provided under our contract with the
   U.S. Department of Energy (DOE).  This work was produced at the
   University of California, Lawrence Livermore National Laboratory under
   Contract No. W-7405-ENG-48 with the DOE.
-   
+
   2. Neither the United States Government nor the University of
   California nor any of their employees, makes any warranty, express or
   implied, or assumes any liability or responsibility for the accuracy,
   completeness, or usefulness of any information, apparatus, product, or
   process disclosed, or represents that its use would not infringe
   privately-owned rights.
-   
+
   3.  Also, reference herein to any specific commercial products,
   process, or services by trade name, trademark, manufacturer or
   otherwise does not necessarily constitute or imply its endorsement,
@@ -436,9 +435,9 @@ extern void *saved_ret_addr;
   herein do not necessarily state or reflect those of the United States
   Government or the University of California, and shall not be used for
   advertising or product endorsement purposes.
-  
+
   </license>
-  
+
 */
 
 /* EOF */


### PR DESCRIPTION
The darwin kernel/macOS/OS X does not have the <malloc.h> header; the
malloc public API is provided by <stdlib.h> instead. A cursory
inspection of the mpiP source code suggests that none of the internal
<malloc.h> API declarations is used in the source code, so it is not
necessary to include it if <malloc.h> is already included.