### PR TITLE
Add multi-thread support to mpiP

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -36,6 +36,7 @@ PC_LOOKUP_OBJ = $(PC_LOOKUP_FILE:.c=.o)
 SRCS =	diag_msgs.c \
 	mpiP-hash.c \
 	mpiP-stats.c \
+	mpiP-tslist.c \
 	glob.c \
 	wrappers.c \
 	wrappers_special.c \

--- a/Makefile.in
+++ b/Makefile.in
@@ -35,6 +35,7 @@ PC_LOOKUP_OBJ = $(PC_LOOKUP_FILE:.c=.o)
 
 SRCS =	diag_msgs.c \
 	mpiP-hash.c \
+	mpiP-callsites.c \
 	mpiP-stats.c \
 	mpiP-mt-stats.c \
 	mpiP-tslist.c \
@@ -52,6 +53,7 @@ SRCS =	diag_msgs.c \
 
 API_SRCS =	diag_msgs_api.c \
 	mpiP-hash.c \
+	mpiP-callsites.c \
 	mpiP-stats.c \
 	mpiP-mt-stats.c \
 	glob.c \

--- a/Makefile.in
+++ b/Makefile.in
@@ -36,6 +36,7 @@ PC_LOOKUP_OBJ = $(PC_LOOKUP_FILE:.c=.o)
 SRCS =	diag_msgs.c \
 	mpiP-hash.c \
 	mpiP-stats.c \
+	mpiP-mt-stats.c \
 	mpiP-tslist.c \
 	glob.c \
 	wrappers.c \
@@ -52,6 +53,7 @@ SRCS =	diag_msgs.c \
 API_SRCS =	diag_msgs_api.c \
 	mpiP-hash.c \
 	mpiP-stats.c \
+	mpiP-mt-stats.c \
 	glob.c \
 	mpiPi.c \
 	util.c \

--- a/arch/arch.h
+++ b/arch/arch.h
@@ -1,0 +1,92 @@
+/* -*- C -*-
+
+   mpiP MPI Profiler ( http://llnl.github.io/mpiP )
+
+   Please see COPYRIGHT AND LICENSE information at the end of this file.
+
+   -----
+
+   arch.h -- architecture-specific code and definitions
+
+ */
+
+#ifndef ARCH_ATOMICS_H
+#define ARCH_ATOMICS_H
+
+#ifdef __x86_64__
+#include "arch/arch_x86_64.h"
+#elif __ppc64__ || __ppc__
+#include "arch/arch_ppc.h"
+#elif __aarch64__
+#include "arch/arch_arm64.h"
+#endif
+
+#endif // ARCH_ATOMICS_H
+
+
+/*
+
+<license>
+
+Copyright (c) 2019      Mellanox Technologies Ltd.
+Written by Artem Polyakov
+All rights reserved.
+
+This file is part of mpiP.  For details, see http://llnl.github.io/mpiP.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the disclaimer below.
+
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the disclaimer (as noted below) in
+the documentation and/or other materials provided with the
+distribution.
+
+* Neither the name of the UC/LLNL nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OF
+THE UNIVERSITY OF CALIFORNIA, THE U.S. DEPARTMENT OF ENERGY OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Additional BSD Notice
+
+1. This notice is required to be provided under our contract with the
+U.S. Department of Energy (DOE).  This work was produced at the
+University of California, Lawrence Livermore National Laboratory under
+Contract No. W-7405-ENG-48 with the DOE.
+
+2. Neither the United States Government nor the University of
+California nor any of their employees, makes any warranty, express or
+implied, or assumes any liability or responsibility for the accuracy,
+completeness, or usefulness of any information, apparatus, product, or
+process disclosed, or represents that its use would not infringe
+privately-owned rights.
+
+3.  Also, reference herein to any specific commercial products,
+process, or services by trade name, trademark, manufacturer or
+otherwise does not necessarily constitute or imply its endorsement,
+recommendation, or favoring by the United States Government or the
+University of California.  The views and opinions of authors expressed
+herein do not necessarily state or reflect those of the United States
+Government or the University of California, and shall not be used for
+advertising or product endorsement purposes.
+
+</license>
+
+*/

--- a/arch/arch_arm64.h
+++ b/arch/arch_arm64.h
@@ -1,0 +1,146 @@
+/* -*- C -*-
+
+   mpiP MPI Profiler ( http://llnl.github.io/mpiP )
+
+   Please see COPYRIGHT AND LICENSE information at the end of this file.
+
+   -----
+
+   arch.h -- code and definitions specific to ARM64 architecture
+
+ */
+
+#ifndef ARCH_ARM64_H
+#define ARCH_ARM64_H
+
+#define MB()  __asm__ __volatile__ ("dmb sy" : : : "memory")
+#define RMB() __asm__ __volatile__ ("dmb ld" : : : "memory")
+#define WMB() __asm__ __volatile__ ("dmb st" : : : "memory")
+
+static inline void opal_atomic_wmb (void)
+{
+  WMB();
+}
+
+static inline void opal_atomic_isync (void)
+{
+  __asm__ __volatile__ ("isb");
+}
+
+static inline int64_t _mpiP_atomic_swap_ldst(int64_t *addr, int64_t newval)
+{
+  int64_t ret;
+  int tmp;
+
+  __asm__ __volatile__ ("1:  ldaxr   %0, [%2]        \n"
+                        "    stlxr   %w1, %3, [%2]   \n"
+                        "    cbnz    %w1, 1b         \n"
+                        : "=&r" (ret), "=&r" (tmp)
+                        : "r" (addr), "r" (newval)
+                        : "cc", "memory");
+
+  return ret;
+}
+
+static inline int64_t _mpiP_atomic_swap_lse(int64_t *addr, int64_t newval)
+{
+  int64_t ret;
+  int tmp;
+
+  __asm__ __volatile__ ("swpl %2, %0, [%1]\n"
+                        : "=&r" (ret)
+                        : "r" (addr), "r" (newval)
+                        : "cc", "memory");
+  return ret;
+}
+
+/* TODO: Detect the support for LSE extentions */
+static inline int64_t mpiP_atomic_swap(int64_t *addr, int64_t newval)
+{
+  return _mpiP_atomic_swap_lse(addr, newval);
+}
+
+#endif
+
+
+/*
+
+<license>
+
+This code was derived from Open MPI OPAL layer.
+
+Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+                        University Research and Technology
+                        Corporation.  All rights reserved.
+Copyright (c) 2004-2005 The University of Tennessee and The University
+                        of Tennessee Research Foundation.  All rights
+                        reserved.
+Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+                        University of Stuttgart.  All rights reserved.
+Copyright (c) 2004-2005 The Regents of the University of California.
+                        All rights reserved.
+Copyright (c) 2010      IBM Corporation.  All rights reserved.
+Copyright (c) 2010      ARM ltd.  All rights reserved.
+Copyright (c) 2016-2018 Los Alamos National Security, LLC. All rights
+                        reserved.
+Copyright (c) 2019      Mellanox Technologies Ltd. All rights reserved.
+
+This file is part of mpiP.  For details, see http://llnl.github.io/mpiP.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the disclaimer below.
+
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the disclaimer (as noted below) in
+the documentation and/or other materials provided with the
+distribution.
+
+* Neither the name of the UC/LLNL nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OF
+THE UNIVERSITY OF CALIFORNIA, THE U.S. DEPARTMENT OF ENERGY OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Additional BSD Notice
+
+1. This notice is required to be provided under our contract with the
+U.S. Department of Energy (DOE).  This work was produced at the
+University of California, Lawrence Livermore National Laboratory under
+Contract No. W-7405-ENG-48 with the DOE.
+
+2. Neither the United States Government nor the University of
+California nor any of their employees, makes any warranty, express or
+implied, or assumes any liability or responsibility for the accuracy,
+completeness, or usefulness of any information, apparatus, product, or
+process disclosed, or represents that its use would not infringe
+privately-owned rights.
+
+3.  Also, reference herein to any specific commercial products,
+process, or services by trade name, trademark, manufacturer or
+otherwise does not necessarily constitute or imply its endorsement,
+recommendation, or favoring by the United States Government or the
+University of California.  The views and opinions of authors expressed
+herein do not necessarily state or reflect those of the United States
+Government or the University of California, and shall not be used for
+advertising or product endorsement purposes.
+
+</license>
+
+*/
+

--- a/arch/arch_ppc.h
+++ b/arch/arch_ppc.h
@@ -1,0 +1,127 @@
+/* -*- C -*-
+
+   mpiP MPI Profiler ( http://llnl.github.io/mpiP )
+
+   Please see COPYRIGHT AND LICENSE information at the end of this file.
+
+   -----
+
+   arch.h -- code and definitions specific to POWER architecture
+
+ */
+
+#ifndef ARCH_PPC_H
+#define ARCH_PPC_H
+
+#define MB()  __asm__ __volatile__ ("sync" : : : "memory")
+#define RMB() __asm__ __volatile__ ("lwsync" : : : "memory")
+#define WMB() __asm__ __volatile__ ("lwsync" : : : "memory")
+#define ISYNC() __asm__ __volatile__ ("isync" : : : "memory")
+
+static inline
+void mpiP_atomic_wmb(void)
+{
+  WMB();
+}
+
+static inline
+void opal_atomic_isync(void)
+{
+  ISYNC();
+}
+
+static inline int64_t mpiP_atomic_swap(int64_t *addr, int64_t newval)
+{
+  int64_t ret;
+
+  __asm__ __volatile__ ("1: ldarx   %0, 0, %2  \n\t"
+                        "   stdcx.  %3, 0, %2  \n\t"
+                        "   bne-    1b         \n\t"
+                        : "=&r" (ret), "=m" (*addr)
+                        : "r" (addr), "r" (OPAL_ASM_VALUE64(newval))
+                        : "cc", "memory");
+
+  return ret;
+}
+
+#endif
+
+/*
+
+<license>
+
+This code was derived from Open MPI OPAL layer.
+
+Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+                        University Research and Technology
+                        Corporation.  All rights reserved.
+Copyright (c) 2004-2005 The University of Tennessee and The University
+                        of Tennessee Research Foundation.  All rights
+                        reserved.
+Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+                        University of Stuttgart.  All rights reserved.
+Copyright (c) 2004-2005 The Regents of the University of California.
+                        All rights reserved.
+Copyright (c) 2010-2017 IBM Corporation.  All rights reserved.
+Copyright (c) 2015-2018 Los Alamos National Security, LLC. All rights
+                        reserved.
+Copyright (c) 2019      Mellanox Technologies Ltd. All rights reserved.
+
+This file is part of mpiP.  For details, see http://llnl.github.io/mpiP.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the disclaimer below.
+
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the disclaimer (as noted below) in
+the documentation and/or other materials provided with the
+distribution.
+
+* Neither the name of the UC/LLNL nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OF
+THE UNIVERSITY OF CALIFORNIA, THE U.S. DEPARTMENT OF ENERGY OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Additional BSD Notice
+
+1. This notice is required to be provided under our contract with the
+U.S. Department of Energy (DOE).  This work was produced at the
+University of California, Lawrence Livermore National Laboratory under
+Contract No. W-7405-ENG-48 with the DOE.
+
+2. Neither the United States Government nor the University of
+California nor any of their employees, makes any warranty, express or
+implied, or assumes any liability or responsibility for the accuracy,
+completeness, or usefulness of any information, apparatus, product, or
+process disclosed, or represents that its use would not infringe
+privately-owned rights.
+
+3.  Also, reference herein to any specific commercial products,
+process, or services by trade name, trademark, manufacturer or
+otherwise does not necessarily constitute or imply its endorsement,
+recommendation, or favoring by the United States Government or the
+University of California.  The views and opinions of authors expressed
+herein do not necessarily state or reflect those of the United States
+Government or the University of California, and shall not be used for
+advertising or product endorsement purposes.
+
+</license>
+
+*/

--- a/arch/arch_x86_64.h
+++ b/arch/arch_x86_64.h
@@ -1,0 +1,111 @@
+#ifndef ARCH_X86_64_H
+#define ARCH_X86_64_H
+
+#include <stdint.h>
+
+#define MB() __asm__ __volatile__("": : :"memory")
+
+static inline void mpiP_atomic_wmb(void)
+{
+  MB();
+}
+
+static inline void mpiP_atomic_isync(void)
+{
+}
+
+static inline int64_t mpiP_atomic_swap(int64_t *addr, int64_t newval)
+{
+  int64_t oldval;
+
+  __asm__ __volatile__("xchgq %1, %0" :
+                       "=r" (oldval), "+m" (*addr) :
+                       "0" (newval) :
+                       "memory");
+  return oldval;
+}
+
+#endif
+
+
+/*
+
+<license>
+
+This code was derived from Open MPI OPAL layer.
+
+Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+                        University Research and Technology
+                        Corporation.  All rights reserved.
+Copyright (c) 2004-2010 The University of Tennessee and The University
+                        of Tennessee Research Foundation.  All rights
+                        reserved.
+Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+                        University of Stuttgart.  All rights reserved.
+Copyright (c) 2004-2005 The Regents of the University of California.
+                        All rights reserved.
+Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserverd.
+Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
+                        reserved.
+Copyright (c) 2016-2017 Research Organization for Information Science
+                        and Technology (RIST). All rights reserved.
+Copyright (c) 2019      Mellanox Technologies Ltd. All rights reserved.
+
+This file is part of mpiP.  For details, see http://llnl.github.io/mpiP.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the disclaimer below.
+
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the disclaimer (as noted below) in
+the documentation and/or other materials provided with the
+distribution.
+
+* Neither the name of the UC/LLNL nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OF
+THE UNIVERSITY OF CALIFORNIA, THE U.S. DEPARTMENT OF ENERGY OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Additional BSD Notice
+
+1. This notice is required to be provided under our contract with the
+U.S. Department of Energy (DOE).  This work was produced at the
+University of California, Lawrence Livermore National Laboratory under
+Contract No. W-7405-ENG-48 with the DOE.
+
+2. Neither the United States Government nor the University of
+California nor any of their employees, makes any warranty, express or
+implied, or assumes any liability or responsibility for the accuracy,
+completeness, or usefulness of any information, apparatus, product, or
+process disclosed, or represents that its use would not infringe
+privately-owned rights.
+
+3.  Also, reference herein to any specific commercial products,
+process, or services by trade name, trademark, manufacturer or
+otherwise does not necessarily constitute or imply its endorsement,
+recommendation, or favoring by the United States Government or the
+University of California.  The views and opinions of authors expressed
+herein do not necessarily state or reflect those of the United States
+Government or the University of California, and shall not be used for
+advertising or product endorsement purposes.
+
+</license>
+
+*/

--- a/arch/arch_x86_64.h
+++ b/arch/arch_x86_64.h
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 
+#define SMPLOCK "lock; "
+
 #define MB() __asm__ __volatile__("": : :"memory")
 
 static inline void mpiP_atomic_wmb(void)
@@ -24,6 +26,21 @@ static inline int64_t mpiP_atomic_swap(int64_t *addr, int64_t newval)
                        "memory");
   return oldval;
 }
+
+static inline int mpiP_atomic_cas(int64_t *addr, int64_t *oldval, int64_t newval)
+{
+   unsigned char ret;
+   __asm__ __volatile__ (
+                       SMPLOCK "cmpxchgq %3,%2   \n\t"
+                               "sete     %0      \n\t"
+                       : "=qm" (ret), "+a" (*oldval), "+m" (*addr)
+                       : "q"(newval)
+                       : "memory", "cc"
+                       );
+
+   return (int) ret;
+}
+
 
 #endif
 

--- a/configure
+++ b/configure
@@ -642,17 +642,9 @@ F77_SYMBOLS
 ac_ct_F77
 USE_RTC
 USE_RTS_GET_TIMEBASE
-EGREP
-GREP
-CPP
-OBJEXT
-EXEEXT
-ac_ct_CC
-CPPFLAGS
 LAUNCH
 F77
 CXX
-CC
 RANLIB
 INSTALL_DATA
 INSTALL_SCRIPT
@@ -670,8 +662,16 @@ BIN_TYPE_FLAG
 LIBUNWIND_LOC
 BINUTILS_DIR
 FFLAGS
-CFLAGS
+EGREP
+GREP
+CPP
+OBJEXT
+EXEEXT
+ac_ct_CC
+CPPFLAGS
 LDFLAGS
+CFLAGS
+CC
 target_os
 target_vendor
 target_cpu
@@ -1578,6 +1578,299 @@ fi
 
 } # ac_fn_c_try_compile
 
+# ac_fn_c_try_run LINENO
+# ----------------------
+# Try to link conftest.$ac_ext, and return whether this succeeded. Assumes
+# that executables *can* be run.
+ac_fn_c_try_run ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  if { { ac_try="$ac_link"
+case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+$as_echo "$ac_try_echo"; } >&5
+  (eval "$ac_link") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; } && { ac_try='./conftest$ac_exeext'
+  { { case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+$as_echo "$ac_try_echo"; } >&5
+  (eval "$ac_try") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; }; then :
+  ac_retval=0
+else
+  $as_echo "$as_me: program exited with status $ac_status" >&5
+       $as_echo "$as_me: failed program was:" >&5
+sed 's/^/| /' conftest.$ac_ext >&5
+
+       ac_retval=$ac_status
+fi
+  rm -rf conftest.dSYM conftest_ipa8_conftest.oo
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+  as_fn_set_status $ac_retval
+
+} # ac_fn_c_try_run
+
+# ac_fn_c_compute_int LINENO EXPR VAR INCLUDES
+# --------------------------------------------
+# Tries to find the compile-time value of EXPR in a program that includes
+# INCLUDES, setting VAR accordingly. Returns whether the value could be
+# computed
+ac_fn_c_compute_int ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  if test "$cross_compiling" = yes; then
+    # Depending upon the size, compute the lo and hi bounds.
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+$4
+int
+main ()
+{
+static int test_array [1 - 2 * !(($2) >= 0)];
+test_array [0] = 0;
+return test_array [0];
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_lo=0 ac_mid=0
+  while :; do
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+$4
+int
+main ()
+{
+static int test_array [1 - 2 * !(($2) <= $ac_mid)];
+test_array [0] = 0;
+return test_array [0];
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_hi=$ac_mid; break
+else
+  as_fn_arith $ac_mid + 1 && ac_lo=$as_val
+			if test $ac_lo -le $ac_mid; then
+			  ac_lo= ac_hi=
+			  break
+			fi
+			as_fn_arith 2 '*' $ac_mid + 1 && ac_mid=$as_val
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  done
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+$4
+int
+main ()
+{
+static int test_array [1 - 2 * !(($2) < 0)];
+test_array [0] = 0;
+return test_array [0];
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_hi=-1 ac_mid=-1
+  while :; do
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+$4
+int
+main ()
+{
+static int test_array [1 - 2 * !(($2) >= $ac_mid)];
+test_array [0] = 0;
+return test_array [0];
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_lo=$ac_mid; break
+else
+  as_fn_arith '(' $ac_mid ')' - 1 && ac_hi=$as_val
+			if test $ac_mid -le $ac_hi; then
+			  ac_lo= ac_hi=
+			  break
+			fi
+			as_fn_arith 2 '*' $ac_mid && ac_mid=$as_val
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  done
+else
+  ac_lo= ac_hi=
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+# Binary search between lo and hi bounds.
+while test "x$ac_lo" != "x$ac_hi"; do
+  as_fn_arith '(' $ac_hi - $ac_lo ')' / 2 + $ac_lo && ac_mid=$as_val
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+$4
+int
+main ()
+{
+static int test_array [1 - 2 * !(($2) <= $ac_mid)];
+test_array [0] = 0;
+return test_array [0];
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_hi=$ac_mid
+else
+  as_fn_arith '(' $ac_mid ')' + 1 && ac_lo=$as_val
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+done
+case $ac_lo in #((
+?*) eval "$3=\$ac_lo"; ac_retval=0 ;;
+'') ac_retval=1 ;;
+esac
+  else
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+$4
+static long int longval () { return $2; }
+static unsigned long int ulongval () { return $2; }
+#include <stdio.h>
+#include <stdlib.h>
+int
+main ()
+{
+
+  FILE *f = fopen ("conftest.val", "w");
+  if (! f)
+    return 1;
+  if (($2) < 0)
+    {
+      long int i = longval ();
+      if (i != ($2))
+	return 1;
+      fprintf (f, "%ld", i);
+    }
+  else
+    {
+      unsigned long int i = ulongval ();
+      if (i != ($2))
+	return 1;
+      fprintf (f, "%lu", i);
+    }
+  /* Do not output a trailing newline, as this causes \r\n confusion
+     on some platforms.  */
+  return ferror (f) || fclose (f) != 0;
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_run "$LINENO"; then :
+  echo >>conftest.val; read $3 <conftest.val; ac_retval=0
+else
+  ac_retval=1
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f conftest.val
+
+  fi
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+  as_fn_set_status $ac_retval
+
+} # ac_fn_c_compute_int
+
+# ac_fn_c_try_cpp LINENO
+# ----------------------
+# Try to preprocess conftest.$ac_ext, and return whether this succeeded.
+ac_fn_c_try_cpp ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  if { { ac_try="$ac_cpp conftest.$ac_ext"
+case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+$as_echo "$ac_try_echo"; } >&5
+  (eval "$ac_cpp conftest.$ac_ext") 2>conftest.err
+  ac_status=$?
+  if test -s conftest.err; then
+    grep -v '^ *+' conftest.err >conftest.er1
+    cat conftest.er1 >&5
+    mv -f conftest.er1 conftest.err
+  fi
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; } > conftest.i && {
+	 test -z "$ac_c_preproc_warn_flag$ac_c_werror_flag" ||
+	 test ! -s conftest.err
+       }; then :
+  ac_retval=0
+else
+  $as_echo "$as_me: failed program was:" >&5
+sed 's/^/| /' conftest.$ac_ext >&5
+
+    ac_retval=1
+fi
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+  as_fn_set_status $ac_retval
+
+} # ac_fn_c_try_cpp
+
+# ac_fn_c_check_header_compile LINENO HEADER VAR INCLUDES
+# -------------------------------------------------------
+# Tests whether HEADER exists and can be compiled using the include files in
+# INCLUDES, setting the cache variable VAR accordingly.
+ac_fn_c_check_header_compile ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
+$as_echo_n "checking for $2... " >&6; }
+if eval \${$3+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+$4
+#include <$2>
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  eval "$3=yes"
+else
+  eval "$3=no"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+eval ac_res=\$$3
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+
+} # ac_fn_c_check_header_compile
+
 # ac_fn_c_try_link LINENO
 # -----------------------
 # Try to link conftest.$ac_ext, and return whether this succeeded.
@@ -1670,43 +1963,6 @@ $as_echo "$ac_res" >&6; }
 
 } # ac_fn_c_check_decl
 
-# ac_fn_c_try_cpp LINENO
-# ----------------------
-# Try to preprocess conftest.$ac_ext, and return whether this succeeded.
-ac_fn_c_try_cpp ()
-{
-  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-  if { { ac_try="$ac_cpp conftest.$ac_ext"
-case "(($ac_try" in
-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
-  *) ac_try_echo=$ac_try;;
-esac
-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-$as_echo "$ac_try_echo"; } >&5
-  (eval "$ac_cpp conftest.$ac_ext") 2>conftest.err
-  ac_status=$?
-  if test -s conftest.err; then
-    grep -v '^ *+' conftest.err >conftest.er1
-    cat conftest.er1 >&5
-    mv -f conftest.er1 conftest.err
-  fi
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; } > conftest.i && {
-	 test -z "$ac_c_preproc_warn_flag$ac_c_werror_flag" ||
-	 test ! -s conftest.err
-       }; then :
-  ac_retval=0
-else
-  $as_echo "$as_me: failed program was:" >&5
-sed 's/^/| /' conftest.$ac_ext >&5
-
-    ac_retval=1
-fi
-  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
-  as_fn_set_status $ac_retval
-
-} # ac_fn_c_try_cpp
-
 # ac_fn_c_check_header_mongrel LINENO HEADER VAR INCLUDES
 # -------------------------------------------------------
 # Tests whether HEADER exists, giving a warning if it cannot be compiled using
@@ -1797,79 +2053,6 @@ fi
   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
 
 } # ac_fn_c_check_header_mongrel
-
-# ac_fn_c_try_run LINENO
-# ----------------------
-# Try to link conftest.$ac_ext, and return whether this succeeded. Assumes
-# that executables *can* be run.
-ac_fn_c_try_run ()
-{
-  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-  if { { ac_try="$ac_link"
-case "(($ac_try" in
-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
-  *) ac_try_echo=$ac_try;;
-esac
-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-$as_echo "$ac_try_echo"; } >&5
-  (eval "$ac_link") 2>&5
-  ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; } && { ac_try='./conftest$ac_exeext'
-  { { case "(($ac_try" in
-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
-  *) ac_try_echo=$ac_try;;
-esac
-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-$as_echo "$ac_try_echo"; } >&5
-  (eval "$ac_try") 2>&5
-  ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }; }; then :
-  ac_retval=0
-else
-  $as_echo "$as_me: program exited with status $ac_status" >&5
-       $as_echo "$as_me: failed program was:" >&5
-sed 's/^/| /' conftest.$ac_ext >&5
-
-       ac_retval=$ac_status
-fi
-  rm -rf conftest.dSYM conftest_ipa8_conftest.oo
-  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
-  as_fn_set_status $ac_retval
-
-} # ac_fn_c_try_run
-
-# ac_fn_c_check_header_compile LINENO HEADER VAR INCLUDES
-# -------------------------------------------------------
-# Tests whether HEADER exists and can be compiled using the include files in
-# INCLUDES, setting the cache variable VAR accordingly.
-ac_fn_c_check_header_compile ()
-{
-  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
-$as_echo_n "checking for $2... " >&6; }
-if eval \${$3+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-$4
-#include <$2>
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  eval "$3=yes"
-else
-  eval "$3=no"
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-fi
-eval ac_res=\$$3
-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-$as_echo "$ac_res" >&6; }
-  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
-
-} # ac_fn_c_check_header_compile
 
 # ac_fn_c_check_type LINENO TYPE VAR INCLUDES
 # -------------------------------------------
@@ -2562,6 +2745,1228 @@ echo
 echo "  Note: mpiP sets cross_compiling to yes to keep configure from failing in"
 echo "        the case where test executables would need to be run as a parallel job."
 echo
+
+ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+if test -n "$ac_tool_prefix"; then
+  # Extract the first word of "${ac_tool_prefix}gcc", so it can be a program name with args.
+set dummy ${ac_tool_prefix}gcc; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_CC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$CC"; then
+  ac_cv_prog_CC="$CC" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_CC="${ac_tool_prefix}gcc"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+CC=$ac_cv_prog_CC
+if test -n "$CC"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
+$as_echo "$CC" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+fi
+if test -z "$ac_cv_prog_CC"; then
+  ac_ct_CC=$CC
+  # Extract the first word of "gcc", so it can be a program name with args.
+set dummy gcc; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_CC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$ac_ct_CC"; then
+  ac_cv_prog_ac_ct_CC="$ac_ct_CC" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_ac_ct_CC="gcc"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+ac_ct_CC=$ac_cv_prog_ac_ct_CC
+if test -n "$ac_ct_CC"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC" >&5
+$as_echo "$ac_ct_CC" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+  if test "x$ac_ct_CC" = x; then
+    CC=""
+  else
+    case $cross_compiling:$ac_tool_warned in
+yes:)
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ac_tool_warned=yes ;;
+esac
+    CC=$ac_ct_CC
+  fi
+else
+  CC="$ac_cv_prog_CC"
+fi
+
+if test -z "$CC"; then
+          if test -n "$ac_tool_prefix"; then
+    # Extract the first word of "${ac_tool_prefix}cc", so it can be a program name with args.
+set dummy ${ac_tool_prefix}cc; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_CC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$CC"; then
+  ac_cv_prog_CC="$CC" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_CC="${ac_tool_prefix}cc"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+CC=$ac_cv_prog_CC
+if test -n "$CC"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
+$as_echo "$CC" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+  fi
+fi
+if test -z "$CC"; then
+  # Extract the first word of "cc", so it can be a program name with args.
+set dummy cc; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_CC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$CC"; then
+  ac_cv_prog_CC="$CC" # Let the user override the test.
+else
+  ac_prog_rejected=no
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    if test "$as_dir/$ac_word$ac_exec_ext" = "/usr/ucb/cc"; then
+       ac_prog_rejected=yes
+       continue
+     fi
+    ac_cv_prog_CC="cc"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+if test $ac_prog_rejected = yes; then
+  # We found a bogon in the path, so make sure we never use it.
+  set dummy $ac_cv_prog_CC
+  shift
+  if test $# != 0; then
+    # We chose a different compiler from the bogus one.
+    # However, it has the same basename, so the bogon will be chosen
+    # first if we set CC to just the basename; use the full file name.
+    shift
+    ac_cv_prog_CC="$as_dir/$ac_word${1+' '}$@"
+  fi
+fi
+fi
+fi
+CC=$ac_cv_prog_CC
+if test -n "$CC"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
+$as_echo "$CC" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+fi
+if test -z "$CC"; then
+  if test -n "$ac_tool_prefix"; then
+  for ac_prog in cl.exe
+  do
+    # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
+set dummy $ac_tool_prefix$ac_prog; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_CC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$CC"; then
+  ac_cv_prog_CC="$CC" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_CC="$ac_tool_prefix$ac_prog"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+CC=$ac_cv_prog_CC
+if test -n "$CC"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
+$as_echo "$CC" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+    test -n "$CC" && break
+  done
+fi
+if test -z "$CC"; then
+  ac_ct_CC=$CC
+  for ac_prog in cl.exe
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_CC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$ac_ct_CC"; then
+  ac_cv_prog_ac_ct_CC="$ac_ct_CC" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_ac_ct_CC="$ac_prog"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+ac_ct_CC=$ac_cv_prog_ac_ct_CC
+if test -n "$ac_ct_CC"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC" >&5
+$as_echo "$ac_ct_CC" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+  test -n "$ac_ct_CC" && break
+done
+
+  if test "x$ac_ct_CC" = x; then
+    CC=""
+  else
+    case $cross_compiling:$ac_tool_warned in
+yes:)
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ac_tool_warned=yes ;;
+esac
+    CC=$ac_ct_CC
+  fi
+fi
+
+fi
+
+
+test -z "$CC" && { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "no acceptable C compiler found in \$PATH
+See \`config.log' for more details" "$LINENO" 5; }
+
+# Provide some information about the compiler.
+$as_echo "$as_me:${as_lineno-$LINENO}: checking for C compiler version" >&5
+set X $ac_compile
+ac_compiler=$2
+for ac_option in --version -v -V -qversion; do
+  { { ac_try="$ac_compiler $ac_option >&5"
+case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+$as_echo "$ac_try_echo"; } >&5
+  (eval "$ac_compiler $ac_option >&5") 2>conftest.err
+  ac_status=$?
+  if test -s conftest.err; then
+    sed '10a\
+... rest of stderr output deleted ...
+         10q' conftest.err >conftest.er1
+    cat conftest.er1 >&5
+  fi
+  rm -f conftest.er1 conftest.err
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }
+done
+
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+ac_clean_files_save=$ac_clean_files
+ac_clean_files="$ac_clean_files a.out a.out.dSYM a.exe b.out"
+# Try to create an executable without -o first, disregard a.out.
+# It will help us diagnose broken compilers, and finding out an intuition
+# of exeext.
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the C compiler works" >&5
+$as_echo_n "checking whether the C compiler works... " >&6; }
+ac_link_default=`$as_echo "$ac_link" | sed 's/ -o *conftest[^ ]*//'`
+
+# The possible output files:
+ac_files="a.out conftest.exe conftest a.exe a_out.exe b.out conftest.*"
+
+ac_rmfiles=
+for ac_file in $ac_files
+do
+  case $ac_file in
+    *.$ac_ext | *.xcoff | *.tds | *.d | *.pdb | *.xSYM | *.bb | *.bbg | *.map | *.inf | *.dSYM | *.o | *.obj ) ;;
+    * ) ac_rmfiles="$ac_rmfiles $ac_file";;
+  esac
+done
+rm -f $ac_rmfiles
+
+if { { ac_try="$ac_link_default"
+case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+$as_echo "$ac_try_echo"; } >&5
+  (eval "$ac_link_default") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then :
+  # Autoconf-2.13 could set the ac_cv_exeext variable to `no'.
+# So ignore a value of `no', otherwise this would lead to `EXEEXT = no'
+# in a Makefile.  We should not override ac_cv_exeext if it was cached,
+# so that the user can short-circuit this test for compilers unknown to
+# Autoconf.
+for ac_file in $ac_files ''
+do
+  test -f "$ac_file" || continue
+  case $ac_file in
+    *.$ac_ext | *.xcoff | *.tds | *.d | *.pdb | *.xSYM | *.bb | *.bbg | *.map | *.inf | *.dSYM | *.o | *.obj )
+	;;
+    [ab].out )
+	# We found the default executable, but exeext='' is most
+	# certainly right.
+	break;;
+    *.* )
+	if test "${ac_cv_exeext+set}" = set && test "$ac_cv_exeext" != no;
+	then :; else
+	   ac_cv_exeext=`expr "$ac_file" : '[^.]*\(\..*\)'`
+	fi
+	# We set ac_cv_exeext here because the later test for it is not
+	# safe: cross compilers may not add the suffix if given an `-o'
+	# argument, so we may need to know it at that point already.
+	# Even if this section looks crufty: it has the advantage of
+	# actually working.
+	break;;
+    * )
+	break;;
+  esac
+done
+test "$ac_cv_exeext" = no && ac_cv_exeext=
+
+else
+  ac_file=''
+fi
+if test -z "$ac_file"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+$as_echo "$as_me: failed program was:" >&5
+sed 's/^/| /' conftest.$ac_ext >&5
+
+{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error 77 "C compiler cannot create executables
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for C compiler default output file name" >&5
+$as_echo_n "checking for C compiler default output file name... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_file" >&5
+$as_echo "$ac_file" >&6; }
+ac_exeext=$ac_cv_exeext
+
+rm -f -r a.out a.out.dSYM a.exe conftest$ac_cv_exeext b.out
+ac_clean_files=$ac_clean_files_save
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for suffix of executables" >&5
+$as_echo_n "checking for suffix of executables... " >&6; }
+if { { ac_try="$ac_link"
+case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+$as_echo "$ac_try_echo"; } >&5
+  (eval "$ac_link") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then :
+  # If both `conftest.exe' and `conftest' are `present' (well, observable)
+# catch `conftest.exe'.  For instance with Cygwin, `ls conftest' will
+# work properly (i.e., refer to `conftest.exe'), while it won't with
+# `rm'.
+for ac_file in conftest.exe conftest conftest.*; do
+  test -f "$ac_file" || continue
+  case $ac_file in
+    *.$ac_ext | *.xcoff | *.tds | *.d | *.pdb | *.xSYM | *.bb | *.bbg | *.map | *.inf | *.dSYM | *.o | *.obj ) ;;
+    *.* ) ac_cv_exeext=`expr "$ac_file" : '[^.]*\(\..*\)'`
+	  break;;
+    * ) break;;
+  esac
+done
+else
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot compute suffix of executables: cannot compile and link
+See \`config.log' for more details" "$LINENO" 5; }
+fi
+rm -f conftest conftest$ac_cv_exeext
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_exeext" >&5
+$as_echo "$ac_cv_exeext" >&6; }
+
+rm -f conftest.$ac_ext
+EXEEXT=$ac_cv_exeext
+ac_exeext=$EXEEXT
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdio.h>
+int
+main ()
+{
+FILE *f = fopen ("conftest.out", "w");
+ return ferror (f) || fclose (f) != 0;
+
+  ;
+  return 0;
+}
+_ACEOF
+ac_clean_files="$ac_clean_files conftest.out"
+# Check that the compiler produces executables we can run.  If not, either
+# the compiler is broken, or we cross compile.
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we are cross compiling" >&5
+$as_echo_n "checking whether we are cross compiling... " >&6; }
+if test "$cross_compiling" != yes; then
+  { { ac_try="$ac_link"
+case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+$as_echo "$ac_try_echo"; } >&5
+  (eval "$ac_link") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }
+  if { ac_try='./conftest$ac_cv_exeext'
+  { { case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+$as_echo "$ac_try_echo"; } >&5
+  (eval "$ac_try") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; }; then
+    cross_compiling=no
+  else
+    if test "$cross_compiling" = maybe; then
+	cross_compiling=yes
+    else
+	{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run C compiled programs.
+If you meant to cross compile, use \`--host'.
+See \`config.log' for more details" "$LINENO" 5; }
+    fi
+  fi
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $cross_compiling" >&5
+$as_echo "$cross_compiling" >&6; }
+
+rm -f conftest.$ac_ext conftest$ac_cv_exeext conftest.out
+ac_clean_files=$ac_clean_files_save
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for suffix of object files" >&5
+$as_echo_n "checking for suffix of object files... " >&6; }
+if ${ac_cv_objext+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+rm -f conftest.o conftest.obj
+if { { ac_try="$ac_compile"
+case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+$as_echo "$ac_try_echo"; } >&5
+  (eval "$ac_compile") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then :
+  for ac_file in conftest.o conftest.obj conftest.*; do
+  test -f "$ac_file" || continue;
+  case $ac_file in
+    *.$ac_ext | *.xcoff | *.tds | *.d | *.pdb | *.xSYM | *.bb | *.bbg | *.map | *.inf | *.dSYM ) ;;
+    *) ac_cv_objext=`expr "$ac_file" : '.*\.\(.*\)'`
+       break;;
+  esac
+done
+else
+  $as_echo "$as_me: failed program was:" >&5
+sed 's/^/| /' conftest.$ac_ext >&5
+
+{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot compute suffix of object files: cannot compile
+See \`config.log' for more details" "$LINENO" 5; }
+fi
+rm -f conftest.$ac_cv_objext conftest.$ac_ext
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_objext" >&5
+$as_echo "$ac_cv_objext" >&6; }
+OBJEXT=$ac_cv_objext
+ac_objext=$OBJEXT
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we are using the GNU C compiler" >&5
+$as_echo_n "checking whether we are using the GNU C compiler... " >&6; }
+if ${ac_cv_c_compiler_gnu+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+#ifndef __GNUC__
+       choke me
+#endif
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_compiler_gnu=yes
+else
+  ac_compiler_gnu=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ac_cv_c_compiler_gnu=$ac_compiler_gnu
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_compiler_gnu" >&5
+$as_echo "$ac_cv_c_compiler_gnu" >&6; }
+if test $ac_compiler_gnu = yes; then
+  GCC=yes
+else
+  GCC=
+fi
+ac_test_CFLAGS=${CFLAGS+set}
+ac_save_CFLAGS=$CFLAGS
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC accepts -g" >&5
+$as_echo_n "checking whether $CC accepts -g... " >&6; }
+if ${ac_cv_prog_cc_g+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_save_c_werror_flag=$ac_c_werror_flag
+   ac_c_werror_flag=yes
+   ac_cv_prog_cc_g=no
+   CFLAGS="-g"
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_prog_cc_g=yes
+else
+  CFLAGS=""
+      cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+else
+  ac_c_werror_flag=$ac_save_c_werror_flag
+	 CFLAGS="-g"
+	 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_prog_cc_g=yes
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+   ac_c_werror_flag=$ac_save_c_werror_flag
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_g" >&5
+$as_echo "$ac_cv_prog_cc_g" >&6; }
+if test "$ac_test_CFLAGS" = set; then
+  CFLAGS=$ac_save_CFLAGS
+elif test $ac_cv_prog_cc_g = yes; then
+  if test "$GCC" = yes; then
+    CFLAGS="-g -O2"
+  else
+    CFLAGS="-g"
+  fi
+else
+  if test "$GCC" = yes; then
+    CFLAGS="-O2"
+  else
+    CFLAGS=
+  fi
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CC option to accept ISO C89" >&5
+$as_echo_n "checking for $CC option to accept ISO C89... " >&6; }
+if ${ac_cv_prog_cc_c89+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_cv_prog_cc_c89=no
+ac_save_CC=$CC
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdarg.h>
+#include <stdio.h>
+struct stat;
+/* Most of the following tests are stolen from RCS 5.7's src/conf.sh.  */
+struct buf { int x; };
+FILE * (*rcsopen) (struct buf *, struct stat *, int);
+static char *e (p, i)
+     char **p;
+     int i;
+{
+  return p[i];
+}
+static char *f (char * (*g) (char **, int), char **p, ...)
+{
+  char *s;
+  va_list v;
+  va_start (v,p);
+  s = g (p, va_arg (v,int));
+  va_end (v);
+  return s;
+}
+
+/* OSF 4.0 Compaq cc is some sort of almost-ANSI by default.  It has
+   function prototypes and stuff, but not '\xHH' hex character constants.
+   These don't provoke an error unfortunately, instead are silently treated
+   as 'x'.  The following induces an error, until -std is added to get
+   proper ANSI mode.  Curiously '\x00'!='x' always comes out true, for an
+   array size at least.  It's necessary to write '\x00'==0 to get something
+   that's true only with -std.  */
+int osf4_cc_array ['\x00' == 0 ? 1 : -1];
+
+/* IBM C 6 for AIX is almost-ANSI by default, but it replaces macro parameters
+   inside strings and character constants.  */
+#define FOO(x) 'x'
+int xlc6_cc_array[FOO(a) == 'x' ? 1 : -1];
+
+int test (int i, double x);
+struct s1 {int (*f) (int a);};
+struct s2 {int (*f) (double a);};
+int pairnames (int, char **, FILE *(*)(struct buf *, struct stat *, int), int, int);
+int argc;
+char **argv;
+int
+main ()
+{
+return f (e, argv, 0) != argv[0]  ||  f (e, argv, 1) != argv[1];
+  ;
+  return 0;
+}
+_ACEOF
+for ac_arg in '' -qlanglvl=extc89 -qlanglvl=ansi -std \
+	-Ae "-Aa -D_HPUX_SOURCE" "-Xc -D__EXTENSIONS__"
+do
+  CC="$ac_save_CC $ac_arg"
+  if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_prog_cc_c89=$ac_arg
+fi
+rm -f core conftest.err conftest.$ac_objext
+  test "x$ac_cv_prog_cc_c89" != "xno" && break
+done
+rm -f conftest.$ac_ext
+CC=$ac_save_CC
+
+fi
+# AC_CACHE_VAL
+case "x$ac_cv_prog_cc_c89" in
+  x)
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
+$as_echo "none needed" >&6; } ;;
+  xno)
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
+$as_echo "unsupported" >&6; } ;;
+  *)
+    CC="$CC $ac_cv_prog_cc_c89"
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_c89" >&5
+$as_echo "$ac_cv_prog_cc_c89" >&6; } ;;
+esac
+if test "x$ac_cv_prog_cc_c89" != xno; then :
+
+fi
+
+ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking how to run the C preprocessor" >&5
+$as_echo_n "checking how to run the C preprocessor... " >&6; }
+# On Suns, sometimes $CPP names a directory.
+if test -n "$CPP" && test -d "$CPP"; then
+  CPP=
+fi
+if test -z "$CPP"; then
+  if ${ac_cv_prog_CPP+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+      # Double quotes because CPP needs to be expanded
+    for CPP in "$CC -E" "$CC -E -traditional-cpp" "/lib/cpp"
+    do
+      ac_preproc_ok=false
+for ac_c_preproc_warn_flag in '' yes
+do
+  # Use a header file that comes with gcc, so configuring glibc
+  # with a fresh cross-compiler works.
+  # Prefer <limits.h> to <assert.h> if __STDC__ is defined, since
+  # <limits.h> exists even on freestanding compilers.
+  # On the NeXT, cc -E runs the code through the compiler's parser,
+  # not just through cpp. "Syntax error" is here to catch this case.
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#ifdef __STDC__
+# include <limits.h>
+#else
+# include <assert.h>
+#endif
+		     Syntax error
+_ACEOF
+if ac_fn_c_try_cpp "$LINENO"; then :
+
+else
+  # Broken: fails on valid input.
+continue
+fi
+rm -f conftest.err conftest.i conftest.$ac_ext
+
+  # OK, works on sane cases.  Now check whether nonexistent headers
+  # can be detected and how.
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <ac_nonexistent.h>
+_ACEOF
+if ac_fn_c_try_cpp "$LINENO"; then :
+  # Broken: success on invalid input.
+continue
+else
+  # Passes both tests.
+ac_preproc_ok=:
+break
+fi
+rm -f conftest.err conftest.i conftest.$ac_ext
+
+done
+# Because of `break', _AC_PREPROC_IFELSE's cleaning code was skipped.
+rm -f conftest.i conftest.err conftest.$ac_ext
+if $ac_preproc_ok; then :
+  break
+fi
+
+    done
+    ac_cv_prog_CPP=$CPP
+
+fi
+  CPP=$ac_cv_prog_CPP
+else
+  ac_cv_prog_CPP=$CPP
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $CPP" >&5
+$as_echo "$CPP" >&6; }
+ac_preproc_ok=false
+for ac_c_preproc_warn_flag in '' yes
+do
+  # Use a header file that comes with gcc, so configuring glibc
+  # with a fresh cross-compiler works.
+  # Prefer <limits.h> to <assert.h> if __STDC__ is defined, since
+  # <limits.h> exists even on freestanding compilers.
+  # On the NeXT, cc -E runs the code through the compiler's parser,
+  # not just through cpp. "Syntax error" is here to catch this case.
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#ifdef __STDC__
+# include <limits.h>
+#else
+# include <assert.h>
+#endif
+		     Syntax error
+_ACEOF
+if ac_fn_c_try_cpp "$LINENO"; then :
+
+else
+  # Broken: fails on valid input.
+continue
+fi
+rm -f conftest.err conftest.i conftest.$ac_ext
+
+  # OK, works on sane cases.  Now check whether nonexistent headers
+  # can be detected and how.
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <ac_nonexistent.h>
+_ACEOF
+if ac_fn_c_try_cpp "$LINENO"; then :
+  # Broken: success on invalid input.
+continue
+else
+  # Passes both tests.
+ac_preproc_ok=:
+break
+fi
+rm -f conftest.err conftest.i conftest.$ac_ext
+
+done
+# Because of `break', _AC_PREPROC_IFELSE's cleaning code was skipped.
+rm -f conftest.i conftest.err conftest.$ac_ext
+if $ac_preproc_ok; then :
+
+else
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "C preprocessor \"$CPP\" fails sanity check
+See \`config.log' for more details" "$LINENO" 5; }
+fi
+
+ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for grep that handles long lines and -e" >&5
+$as_echo_n "checking for grep that handles long lines and -e... " >&6; }
+if ${ac_cv_path_GREP+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -z "$GREP"; then
+  ac_path_GREP_found=false
+  # Loop through the user's path and test for each of PROGNAME-LIST
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH$PATH_SEPARATOR/usr/xpg4/bin
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_prog in grep ggrep; do
+    for ac_exec_ext in '' $ac_executable_extensions; do
+      ac_path_GREP="$as_dir/$ac_prog$ac_exec_ext"
+      as_fn_executable_p "$ac_path_GREP" || continue
+# Check for GNU ac_path_GREP and select it if it is found.
+  # Check for GNU $ac_path_GREP
+case `"$ac_path_GREP" --version 2>&1` in
+*GNU*)
+  ac_cv_path_GREP="$ac_path_GREP" ac_path_GREP_found=:;;
+*)
+  ac_count=0
+  $as_echo_n 0123456789 >"conftest.in"
+  while :
+  do
+    cat "conftest.in" "conftest.in" >"conftest.tmp"
+    mv "conftest.tmp" "conftest.in"
+    cp "conftest.in" "conftest.nl"
+    $as_echo 'GREP' >> "conftest.nl"
+    "$ac_path_GREP" -e 'GREP$' -e '-(cannot match)-' < "conftest.nl" >"conftest.out" 2>/dev/null || break
+    diff "conftest.out" "conftest.nl" >/dev/null 2>&1 || break
+    as_fn_arith $ac_count + 1 && ac_count=$as_val
+    if test $ac_count -gt ${ac_path_GREP_max-0}; then
+      # Best one so far, save it but keep looking for a better one
+      ac_cv_path_GREP="$ac_path_GREP"
+      ac_path_GREP_max=$ac_count
+    fi
+    # 10*(2^10) chars as input seems more than enough
+    test $ac_count -gt 10 && break
+  done
+  rm -f conftest.in conftest.tmp conftest.nl conftest.out;;
+esac
+
+      $ac_path_GREP_found && break 3
+    done
+  done
+  done
+IFS=$as_save_IFS
+  if test -z "$ac_cv_path_GREP"; then
+    as_fn_error $? "no acceptable grep could be found in $PATH$PATH_SEPARATOR/usr/xpg4/bin" "$LINENO" 5
+  fi
+else
+  ac_cv_path_GREP=$GREP
+fi
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_GREP" >&5
+$as_echo "$ac_cv_path_GREP" >&6; }
+ GREP="$ac_cv_path_GREP"
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for egrep" >&5
+$as_echo_n "checking for egrep... " >&6; }
+if ${ac_cv_path_EGREP+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if echo a | $GREP -E '(a|b)' >/dev/null 2>&1
+   then ac_cv_path_EGREP="$GREP -E"
+   else
+     if test -z "$EGREP"; then
+  ac_path_EGREP_found=false
+  # Loop through the user's path and test for each of PROGNAME-LIST
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH$PATH_SEPARATOR/usr/xpg4/bin
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_prog in egrep; do
+    for ac_exec_ext in '' $ac_executable_extensions; do
+      ac_path_EGREP="$as_dir/$ac_prog$ac_exec_ext"
+      as_fn_executable_p "$ac_path_EGREP" || continue
+# Check for GNU ac_path_EGREP and select it if it is found.
+  # Check for GNU $ac_path_EGREP
+case `"$ac_path_EGREP" --version 2>&1` in
+*GNU*)
+  ac_cv_path_EGREP="$ac_path_EGREP" ac_path_EGREP_found=:;;
+*)
+  ac_count=0
+  $as_echo_n 0123456789 >"conftest.in"
+  while :
+  do
+    cat "conftest.in" "conftest.in" >"conftest.tmp"
+    mv "conftest.tmp" "conftest.in"
+    cp "conftest.in" "conftest.nl"
+    $as_echo 'EGREP' >> "conftest.nl"
+    "$ac_path_EGREP" 'EGREP$' < "conftest.nl" >"conftest.out" 2>/dev/null || break
+    diff "conftest.out" "conftest.nl" >/dev/null 2>&1 || break
+    as_fn_arith $ac_count + 1 && ac_count=$as_val
+    if test $ac_count -gt ${ac_path_EGREP_max-0}; then
+      # Best one so far, save it but keep looking for a better one
+      ac_cv_path_EGREP="$ac_path_EGREP"
+      ac_path_EGREP_max=$ac_count
+    fi
+    # 10*(2^10) chars as input seems more than enough
+    test $ac_count -gt 10 && break
+  done
+  rm -f conftest.in conftest.tmp conftest.nl conftest.out;;
+esac
+
+      $ac_path_EGREP_found && break 3
+    done
+  done
+  done
+IFS=$as_save_IFS
+  if test -z "$ac_cv_path_EGREP"; then
+    as_fn_error $? "no acceptable egrep could be found in $PATH$PATH_SEPARATOR/usr/xpg4/bin" "$LINENO" 5
+  fi
+else
+  ac_cv_path_EGREP=$EGREP
+fi
+
+   fi
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_EGREP" >&5
+$as_echo "$ac_cv_path_EGREP" >&6; }
+ EGREP="$ac_cv_path_EGREP"
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for ANSI C header files" >&5
+$as_echo_n "checking for ANSI C header files... " >&6; }
+if ${ac_cv_header_stdc+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+#include <float.h>
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_header_stdc=yes
+else
+  ac_cv_header_stdc=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+if test $ac_cv_header_stdc = yes; then
+  # SunOS 4.x string.h does not declare mem*, contrary to ANSI.
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <string.h>
+
+_ACEOF
+if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+  $EGREP "memchr" >/dev/null 2>&1; then :
+
+else
+  ac_cv_header_stdc=no
+fi
+rm -f conftest*
+
+fi
+
+if test $ac_cv_header_stdc = yes; then
+  # ISC 2.0.2 stdlib.h does not declare free, contrary to ANSI.
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdlib.h>
+
+_ACEOF
+if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+  $EGREP "free" >/dev/null 2>&1; then :
+
+else
+  ac_cv_header_stdc=no
+fi
+rm -f conftest*
+
+fi
+
+if test $ac_cv_header_stdc = yes; then
+  # /bin/cc in Irix-4.0.5 gets non-ANSI ctype macros unless using -ansi.
+  if test "$cross_compiling" = yes; then :
+  :
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <ctype.h>
+#include <stdlib.h>
+#if ((' ' & 0x0FF) == 0x020)
+# define ISLOWER(c) ('a' <= (c) && (c) <= 'z')
+# define TOUPPER(c) (ISLOWER(c) ? 'A' + ((c) - 'a') : (c))
+#else
+# define ISLOWER(c) \
+		   (('a' <= (c) && (c) <= 'i') \
+		     || ('j' <= (c) && (c) <= 'r') \
+		     || ('s' <= (c) && (c) <= 'z'))
+# define TOUPPER(c) (ISLOWER(c) ? ((c) | 0x40) : (c))
+#endif
+
+#define XOR(e, f) (((e) && !(f)) || (!(e) && (f)))
+int
+main ()
+{
+  int i;
+  for (i = 0; i < 256; i++)
+    if (XOR (islower (i), ISLOWER (i))
+	|| toupper (i) != TOUPPER (i))
+      return 2;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_run "$LINENO"; then :
+
+else
+  ac_cv_header_stdc=no
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+fi
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_header_stdc" >&5
+$as_echo "$ac_cv_header_stdc" >&6; }
+if test $ac_cv_header_stdc = yes; then
+
+$as_echo "#define STDC_HEADERS 1" >>confdefs.h
+
+fi
+
+# On IRIX 5.3, sys/types and inttypes.h are conflicting.
+for ac_header in sys/types.h sys/stat.h stdlib.h string.h memory.h strings.h \
+		  inttypes.h stdint.h unistd.h
+do :
+  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+ac_fn_c_check_header_compile "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default
+"
+if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
+_ACEOF
+
+fi
+
+done
+
+
+# The cast to long int works around a bug in the HP C Compiler
+# version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
+# declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
+# This bug is HP SR number 8606223364.
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of void*" >&5
+$as_echo_n "checking size of void*... " >&6; }
+if ${ac_cv_sizeof_voidp+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if ac_fn_c_compute_int "$LINENO" "(long int) (sizeof (void*))" "ac_cv_sizeof_voidp"        "$ac_includes_default"; then :
+
+else
+  if test "$ac_cv_type_voidp" = yes; then
+     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error 77 "cannot compute sizeof (void*)
+See \`config.log' for more details" "$LINENO" 5; }
+   else
+     ac_cv_sizeof_voidp=0
+   fi
+fi
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_voidp" >&5
+$as_echo "$ac_cv_sizeof_voidp" >&6; }
+
+
+
+cat >>confdefs.h <<_ACEOF
+#define SIZEOF_VOIDP $ac_cv_sizeof_voidp
+_ACEOF
+
+
+
 
 #
 #  With specifications
@@ -3511,796 +4916,6 @@ test -n "$F77" || F77="mpif77"
   TEST_LIST="api-test.exp"
 fi
 
-ac_ext=c
-ac_cpp='$CPP $CPPFLAGS'
-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-if test -n "$ac_tool_prefix"; then
-  # Extract the first word of "${ac_tool_prefix}gcc", so it can be a program name with args.
-set dummy ${ac_tool_prefix}gcc; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_CC+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  if test -n "$CC"; then
-  ac_cv_prog_CC="$CC" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_prog_CC="${ac_tool_prefix}gcc"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-fi
-fi
-CC=$ac_cv_prog_CC
-if test -n "$CC"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
-$as_echo "$CC" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-fi
-if test -z "$ac_cv_prog_CC"; then
-  ac_ct_CC=$CC
-  # Extract the first word of "gcc", so it can be a program name with args.
-set dummy gcc; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_ac_ct_CC+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  if test -n "$ac_ct_CC"; then
-  ac_cv_prog_ac_ct_CC="$ac_ct_CC" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_prog_ac_ct_CC="gcc"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-fi
-fi
-ac_ct_CC=$ac_cv_prog_ac_ct_CC
-if test -n "$ac_ct_CC"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC" >&5
-$as_echo "$ac_ct_CC" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-  if test "x$ac_ct_CC" = x; then
-    CC=""
-  else
-    case $cross_compiling:$ac_tool_warned in
-yes:)
-{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
-ac_tool_warned=yes ;;
-esac
-    CC=$ac_ct_CC
-  fi
-else
-  CC="$ac_cv_prog_CC"
-fi
-
-if test -z "$CC"; then
-          if test -n "$ac_tool_prefix"; then
-    # Extract the first word of "${ac_tool_prefix}cc", so it can be a program name with args.
-set dummy ${ac_tool_prefix}cc; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_CC+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  if test -n "$CC"; then
-  ac_cv_prog_CC="$CC" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_prog_CC="${ac_tool_prefix}cc"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-fi
-fi
-CC=$ac_cv_prog_CC
-if test -n "$CC"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
-$as_echo "$CC" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-  fi
-fi
-if test -z "$CC"; then
-  # Extract the first word of "cc", so it can be a program name with args.
-set dummy cc; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_CC+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  if test -n "$CC"; then
-  ac_cv_prog_CC="$CC" # Let the user override the test.
-else
-  ac_prog_rejected=no
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    if test "$as_dir/$ac_word$ac_exec_ext" = "/usr/ucb/cc"; then
-       ac_prog_rejected=yes
-       continue
-     fi
-    ac_cv_prog_CC="cc"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-if test $ac_prog_rejected = yes; then
-  # We found a bogon in the path, so make sure we never use it.
-  set dummy $ac_cv_prog_CC
-  shift
-  if test $# != 0; then
-    # We chose a different compiler from the bogus one.
-    # However, it has the same basename, so the bogon will be chosen
-    # first if we set CC to just the basename; use the full file name.
-    shift
-    ac_cv_prog_CC="$as_dir/$ac_word${1+' '}$@"
-  fi
-fi
-fi
-fi
-CC=$ac_cv_prog_CC
-if test -n "$CC"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
-$as_echo "$CC" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-fi
-if test -z "$CC"; then
-  if test -n "$ac_tool_prefix"; then
-  for ac_prog in cl.exe
-  do
-    # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
-set dummy $ac_tool_prefix$ac_prog; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_CC+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  if test -n "$CC"; then
-  ac_cv_prog_CC="$CC" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_prog_CC="$ac_tool_prefix$ac_prog"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-fi
-fi
-CC=$ac_cv_prog_CC
-if test -n "$CC"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
-$as_echo "$CC" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-    test -n "$CC" && break
-  done
-fi
-if test -z "$CC"; then
-  ac_ct_CC=$CC
-  for ac_prog in cl.exe
-do
-  # Extract the first word of "$ac_prog", so it can be a program name with args.
-set dummy $ac_prog; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_ac_ct_CC+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  if test -n "$ac_ct_CC"; then
-  ac_cv_prog_ac_ct_CC="$ac_ct_CC" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_prog_ac_ct_CC="$ac_prog"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-fi
-fi
-ac_ct_CC=$ac_cv_prog_ac_ct_CC
-if test -n "$ac_ct_CC"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC" >&5
-$as_echo "$ac_ct_CC" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-  test -n "$ac_ct_CC" && break
-done
-
-  if test "x$ac_ct_CC" = x; then
-    CC=""
-  else
-    case $cross_compiling:$ac_tool_warned in
-yes:)
-{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
-ac_tool_warned=yes ;;
-esac
-    CC=$ac_ct_CC
-  fi
-fi
-
-fi
-
-
-test -z "$CC" && { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "no acceptable C compiler found in \$PATH
-See \`config.log' for more details" "$LINENO" 5; }
-
-# Provide some information about the compiler.
-$as_echo "$as_me:${as_lineno-$LINENO}: checking for C compiler version" >&5
-set X $ac_compile
-ac_compiler=$2
-for ac_option in --version -v -V -qversion; do
-  { { ac_try="$ac_compiler $ac_option >&5"
-case "(($ac_try" in
-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
-  *) ac_try_echo=$ac_try;;
-esac
-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-$as_echo "$ac_try_echo"; } >&5
-  (eval "$ac_compiler $ac_option >&5") 2>conftest.err
-  ac_status=$?
-  if test -s conftest.err; then
-    sed '10a\
-... rest of stderr output deleted ...
-         10q' conftest.err >conftest.er1
-    cat conftest.er1 >&5
-  fi
-  rm -f conftest.er1 conftest.err
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }
-done
-
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-ac_clean_files_save=$ac_clean_files
-ac_clean_files="$ac_clean_files a.out a.out.dSYM a.exe b.out"
-# Try to create an executable without -o first, disregard a.out.
-# It will help us diagnose broken compilers, and finding out an intuition
-# of exeext.
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the C compiler works" >&5
-$as_echo_n "checking whether the C compiler works... " >&6; }
-ac_link_default=`$as_echo "$ac_link" | sed 's/ -o *conftest[^ ]*//'`
-
-# The possible output files:
-ac_files="a.out conftest.exe conftest a.exe a_out.exe b.out conftest.*"
-
-ac_rmfiles=
-for ac_file in $ac_files
-do
-  case $ac_file in
-    *.$ac_ext | *.xcoff | *.tds | *.d | *.pdb | *.xSYM | *.bb | *.bbg | *.map | *.inf | *.dSYM | *.o | *.obj ) ;;
-    * ) ac_rmfiles="$ac_rmfiles $ac_file";;
-  esac
-done
-rm -f $ac_rmfiles
-
-if { { ac_try="$ac_link_default"
-case "(($ac_try" in
-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
-  *) ac_try_echo=$ac_try;;
-esac
-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-$as_echo "$ac_try_echo"; } >&5
-  (eval "$ac_link_default") 2>&5
-  ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }; then :
-  # Autoconf-2.13 could set the ac_cv_exeext variable to `no'.
-# So ignore a value of `no', otherwise this would lead to `EXEEXT = no'
-# in a Makefile.  We should not override ac_cv_exeext if it was cached,
-# so that the user can short-circuit this test for compilers unknown to
-# Autoconf.
-for ac_file in $ac_files ''
-do
-  test -f "$ac_file" || continue
-  case $ac_file in
-    *.$ac_ext | *.xcoff | *.tds | *.d | *.pdb | *.xSYM | *.bb | *.bbg | *.map | *.inf | *.dSYM | *.o | *.obj )
-	;;
-    [ab].out )
-	# We found the default executable, but exeext='' is most
-	# certainly right.
-	break;;
-    *.* )
-	if test "${ac_cv_exeext+set}" = set && test "$ac_cv_exeext" != no;
-	then :; else
-	   ac_cv_exeext=`expr "$ac_file" : '[^.]*\(\..*\)'`
-	fi
-	# We set ac_cv_exeext here because the later test for it is not
-	# safe: cross compilers may not add the suffix if given an `-o'
-	# argument, so we may need to know it at that point already.
-	# Even if this section looks crufty: it has the advantage of
-	# actually working.
-	break;;
-    * )
-	break;;
-  esac
-done
-test "$ac_cv_exeext" = no && ac_cv_exeext=
-
-else
-  ac_file=''
-fi
-if test -z "$ac_file"; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-$as_echo "$as_me: failed program was:" >&5
-sed 's/^/| /' conftest.$ac_ext >&5
-
-{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error 77 "C compiler cannot create executables
-See \`config.log' for more details" "$LINENO" 5; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for C compiler default output file name" >&5
-$as_echo_n "checking for C compiler default output file name... " >&6; }
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_file" >&5
-$as_echo "$ac_file" >&6; }
-ac_exeext=$ac_cv_exeext
-
-rm -f -r a.out a.out.dSYM a.exe conftest$ac_cv_exeext b.out
-ac_clean_files=$ac_clean_files_save
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for suffix of executables" >&5
-$as_echo_n "checking for suffix of executables... " >&6; }
-if { { ac_try="$ac_link"
-case "(($ac_try" in
-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
-  *) ac_try_echo=$ac_try;;
-esac
-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-$as_echo "$ac_try_echo"; } >&5
-  (eval "$ac_link") 2>&5
-  ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }; then :
-  # If both `conftest.exe' and `conftest' are `present' (well, observable)
-# catch `conftest.exe'.  For instance with Cygwin, `ls conftest' will
-# work properly (i.e., refer to `conftest.exe'), while it won't with
-# `rm'.
-for ac_file in conftest.exe conftest conftest.*; do
-  test -f "$ac_file" || continue
-  case $ac_file in
-    *.$ac_ext | *.xcoff | *.tds | *.d | *.pdb | *.xSYM | *.bb | *.bbg | *.map | *.inf | *.dSYM | *.o | *.obj ) ;;
-    *.* ) ac_cv_exeext=`expr "$ac_file" : '[^.]*\(\..*\)'`
-	  break;;
-    * ) break;;
-  esac
-done
-else
-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "cannot compute suffix of executables: cannot compile and link
-See \`config.log' for more details" "$LINENO" 5; }
-fi
-rm -f conftest conftest$ac_cv_exeext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_exeext" >&5
-$as_echo "$ac_cv_exeext" >&6; }
-
-rm -f conftest.$ac_ext
-EXEEXT=$ac_cv_exeext
-ac_exeext=$EXEEXT
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <stdio.h>
-int
-main ()
-{
-FILE *f = fopen ("conftest.out", "w");
- return ferror (f) || fclose (f) != 0;
-
-  ;
-  return 0;
-}
-_ACEOF
-ac_clean_files="$ac_clean_files conftest.out"
-# Check that the compiler produces executables we can run.  If not, either
-# the compiler is broken, or we cross compile.
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we are cross compiling" >&5
-$as_echo_n "checking whether we are cross compiling... " >&6; }
-if test "$cross_compiling" != yes; then
-  { { ac_try="$ac_link"
-case "(($ac_try" in
-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
-  *) ac_try_echo=$ac_try;;
-esac
-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-$as_echo "$ac_try_echo"; } >&5
-  (eval "$ac_link") 2>&5
-  ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }
-  if { ac_try='./conftest$ac_cv_exeext'
-  { { case "(($ac_try" in
-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
-  *) ac_try_echo=$ac_try;;
-esac
-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-$as_echo "$ac_try_echo"; } >&5
-  (eval "$ac_try") 2>&5
-  ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }; }; then
-    cross_compiling=no
-  else
-    if test "$cross_compiling" = maybe; then
-	cross_compiling=yes
-    else
-	{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "cannot run C compiled programs.
-If you meant to cross compile, use \`--host'.
-See \`config.log' for more details" "$LINENO" 5; }
-    fi
-  fi
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $cross_compiling" >&5
-$as_echo "$cross_compiling" >&6; }
-
-rm -f conftest.$ac_ext conftest$ac_cv_exeext conftest.out
-ac_clean_files=$ac_clean_files_save
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for suffix of object files" >&5
-$as_echo_n "checking for suffix of object files... " >&6; }
-if ${ac_cv_objext+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-rm -f conftest.o conftest.obj
-if { { ac_try="$ac_compile"
-case "(($ac_try" in
-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
-  *) ac_try_echo=$ac_try;;
-esac
-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-$as_echo "$ac_try_echo"; } >&5
-  (eval "$ac_compile") 2>&5
-  ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }; then :
-  for ac_file in conftest.o conftest.obj conftest.*; do
-  test -f "$ac_file" || continue;
-  case $ac_file in
-    *.$ac_ext | *.xcoff | *.tds | *.d | *.pdb | *.xSYM | *.bb | *.bbg | *.map | *.inf | *.dSYM ) ;;
-    *) ac_cv_objext=`expr "$ac_file" : '.*\.\(.*\)'`
-       break;;
-  esac
-done
-else
-  $as_echo "$as_me: failed program was:" >&5
-sed 's/^/| /' conftest.$ac_ext >&5
-
-{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "cannot compute suffix of object files: cannot compile
-See \`config.log' for more details" "$LINENO" 5; }
-fi
-rm -f conftest.$ac_cv_objext conftest.$ac_ext
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_objext" >&5
-$as_echo "$ac_cv_objext" >&6; }
-OBJEXT=$ac_cv_objext
-ac_objext=$OBJEXT
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we are using the GNU C compiler" >&5
-$as_echo_n "checking whether we are using the GNU C compiler... " >&6; }
-if ${ac_cv_c_compiler_gnu+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main ()
-{
-#ifndef __GNUC__
-       choke me
-#endif
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  ac_compiler_gnu=yes
-else
-  ac_compiler_gnu=no
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-ac_cv_c_compiler_gnu=$ac_compiler_gnu
-
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_compiler_gnu" >&5
-$as_echo "$ac_cv_c_compiler_gnu" >&6; }
-if test $ac_compiler_gnu = yes; then
-  GCC=yes
-else
-  GCC=
-fi
-ac_test_CFLAGS=${CFLAGS+set}
-ac_save_CFLAGS=$CFLAGS
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC accepts -g" >&5
-$as_echo_n "checking whether $CC accepts -g... " >&6; }
-if ${ac_cv_prog_cc_g+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_save_c_werror_flag=$ac_c_werror_flag
-   ac_c_werror_flag=yes
-   ac_cv_prog_cc_g=no
-   CFLAGS="-g"
-   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  ac_cv_prog_cc_g=yes
-else
-  CFLAGS=""
-      cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-else
-  ac_c_werror_flag=$ac_save_c_werror_flag
-	 CFLAGS="-g"
-	 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  ac_cv_prog_cc_g=yes
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-   ac_c_werror_flag=$ac_save_c_werror_flag
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_g" >&5
-$as_echo "$ac_cv_prog_cc_g" >&6; }
-if test "$ac_test_CFLAGS" = set; then
-  CFLAGS=$ac_save_CFLAGS
-elif test $ac_cv_prog_cc_g = yes; then
-  if test "$GCC" = yes; then
-    CFLAGS="-g -O2"
-  else
-    CFLAGS="-g"
-  fi
-else
-  if test "$GCC" = yes; then
-    CFLAGS="-O2"
-  else
-    CFLAGS=
-  fi
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CC option to accept ISO C89" >&5
-$as_echo_n "checking for $CC option to accept ISO C89... " >&6; }
-if ${ac_cv_prog_cc_c89+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_cv_prog_cc_c89=no
-ac_save_CC=$CC
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <stdarg.h>
-#include <stdio.h>
-struct stat;
-/* Most of the following tests are stolen from RCS 5.7's src/conf.sh.  */
-struct buf { int x; };
-FILE * (*rcsopen) (struct buf *, struct stat *, int);
-static char *e (p, i)
-     char **p;
-     int i;
-{
-  return p[i];
-}
-static char *f (char * (*g) (char **, int), char **p, ...)
-{
-  char *s;
-  va_list v;
-  va_start (v,p);
-  s = g (p, va_arg (v,int));
-  va_end (v);
-  return s;
-}
-
-/* OSF 4.0 Compaq cc is some sort of almost-ANSI by default.  It has
-   function prototypes and stuff, but not '\xHH' hex character constants.
-   These don't provoke an error unfortunately, instead are silently treated
-   as 'x'.  The following induces an error, until -std is added to get
-   proper ANSI mode.  Curiously '\x00'!='x' always comes out true, for an
-   array size at least.  It's necessary to write '\x00'==0 to get something
-   that's true only with -std.  */
-int osf4_cc_array ['\x00' == 0 ? 1 : -1];
-
-/* IBM C 6 for AIX is almost-ANSI by default, but it replaces macro parameters
-   inside strings and character constants.  */
-#define FOO(x) 'x'
-int xlc6_cc_array[FOO(a) == 'x' ? 1 : -1];
-
-int test (int i, double x);
-struct s1 {int (*f) (int a);};
-struct s2 {int (*f) (double a);};
-int pairnames (int, char **, FILE *(*)(struct buf *, struct stat *, int), int, int);
-int argc;
-char **argv;
-int
-main ()
-{
-return f (e, argv, 0) != argv[0]  ||  f (e, argv, 1) != argv[1];
-  ;
-  return 0;
-}
-_ACEOF
-for ac_arg in '' -qlanglvl=extc89 -qlanglvl=ansi -std \
-	-Ae "-Aa -D_HPUX_SOURCE" "-Xc -D__EXTENSIONS__"
-do
-  CC="$ac_save_CC $ac_arg"
-  if ac_fn_c_try_compile "$LINENO"; then :
-  ac_cv_prog_cc_c89=$ac_arg
-fi
-rm -f core conftest.err conftest.$ac_objext
-  test "x$ac_cv_prog_cc_c89" != "xno" && break
-done
-rm -f conftest.$ac_ext
-CC=$ac_save_CC
-
-fi
-# AC_CACHE_VAL
-case "x$ac_cv_prog_cc_c89" in
-  x)
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
-$as_echo "none needed" >&6; } ;;
-  xno)
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
-$as_echo "unsupported" >&6; } ;;
-  *)
-    CC="$CC $ac_cv_prog_cc_c89"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_c89" >&5
-$as_echo "$ac_cv_prog_cc_c89" >&6; } ;;
-esac
-if test "x$ac_cv_prog_cc_c89" != xno; then :
-
-fi
-
-ac_ext=c
-ac_cpp='$CPP $CPPFLAGS'
-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for sqrt in -lm" >&5
 $as_echo_n "checking for sqrt in -lm... " >&6; }
 if ${ac_cv_lib_m_sqrt+:} false; then :
@@ -4540,404 +5155,7 @@ if test "x$ac_cv_lib_iberty_objalloc_create" = xyes; then :
   BFD_AUX_LIBS="$BFD_AUX_LIBS -liberty"
 fi
 
-  ac_ext=c
-ac_cpp='$CPP $CPPFLAGS'
-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking how to run the C preprocessor" >&5
-$as_echo_n "checking how to run the C preprocessor... " >&6; }
-# On Suns, sometimes $CPP names a directory.
-if test -n "$CPP" && test -d "$CPP"; then
-  CPP=
-fi
-if test -z "$CPP"; then
-  if ${ac_cv_prog_CPP+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-      # Double quotes because CPP needs to be expanded
-    for CPP in "$CC -E" "$CC -E -traditional-cpp" "/lib/cpp"
-    do
-      ac_preproc_ok=false
-for ac_c_preproc_warn_flag in '' yes
-do
-  # Use a header file that comes with gcc, so configuring glibc
-  # with a fresh cross-compiler works.
-  # Prefer <limits.h> to <assert.h> if __STDC__ is defined, since
-  # <limits.h> exists even on freestanding compilers.
-  # On the NeXT, cc -E runs the code through the compiler's parser,
-  # not just through cpp. "Syntax error" is here to catch this case.
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#ifdef __STDC__
-# include <limits.h>
-#else
-# include <assert.h>
-#endif
-		     Syntax error
-_ACEOF
-if ac_fn_c_try_cpp "$LINENO"; then :
-
-else
-  # Broken: fails on valid input.
-continue
-fi
-rm -f conftest.err conftest.i conftest.$ac_ext
-
-  # OK, works on sane cases.  Now check whether nonexistent headers
-  # can be detected and how.
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <ac_nonexistent.h>
-_ACEOF
-if ac_fn_c_try_cpp "$LINENO"; then :
-  # Broken: success on invalid input.
-continue
-else
-  # Passes both tests.
-ac_preproc_ok=:
-break
-fi
-rm -f conftest.err conftest.i conftest.$ac_ext
-
-done
-# Because of `break', _AC_PREPROC_IFELSE's cleaning code was skipped.
-rm -f conftest.i conftest.err conftest.$ac_ext
-if $ac_preproc_ok; then :
-  break
-fi
-
-    done
-    ac_cv_prog_CPP=$CPP
-
-fi
-  CPP=$ac_cv_prog_CPP
-else
-  ac_cv_prog_CPP=$CPP
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $CPP" >&5
-$as_echo "$CPP" >&6; }
-ac_preproc_ok=false
-for ac_c_preproc_warn_flag in '' yes
-do
-  # Use a header file that comes with gcc, so configuring glibc
-  # with a fresh cross-compiler works.
-  # Prefer <limits.h> to <assert.h> if __STDC__ is defined, since
-  # <limits.h> exists even on freestanding compilers.
-  # On the NeXT, cc -E runs the code through the compiler's parser,
-  # not just through cpp. "Syntax error" is here to catch this case.
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#ifdef __STDC__
-# include <limits.h>
-#else
-# include <assert.h>
-#endif
-		     Syntax error
-_ACEOF
-if ac_fn_c_try_cpp "$LINENO"; then :
-
-else
-  # Broken: fails on valid input.
-continue
-fi
-rm -f conftest.err conftest.i conftest.$ac_ext
-
-  # OK, works on sane cases.  Now check whether nonexistent headers
-  # can be detected and how.
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <ac_nonexistent.h>
-_ACEOF
-if ac_fn_c_try_cpp "$LINENO"; then :
-  # Broken: success on invalid input.
-continue
-else
-  # Passes both tests.
-ac_preproc_ok=:
-break
-fi
-rm -f conftest.err conftest.i conftest.$ac_ext
-
-done
-# Because of `break', _AC_PREPROC_IFELSE's cleaning code was skipped.
-rm -f conftest.i conftest.err conftest.$ac_ext
-if $ac_preproc_ok; then :
-
-else
-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "C preprocessor \"$CPP\" fails sanity check
-See \`config.log' for more details" "$LINENO" 5; }
-fi
-
-ac_ext=c
-ac_cpp='$CPP $CPPFLAGS'
-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-
-
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for grep that handles long lines and -e" >&5
-$as_echo_n "checking for grep that handles long lines and -e... " >&6; }
-if ${ac_cv_path_GREP+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  if test -z "$GREP"; then
-  ac_path_GREP_found=false
-  # Loop through the user's path and test for each of PROGNAME-LIST
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH$PATH_SEPARATOR/usr/xpg4/bin
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_prog in grep ggrep; do
-    for ac_exec_ext in '' $ac_executable_extensions; do
-      ac_path_GREP="$as_dir/$ac_prog$ac_exec_ext"
-      as_fn_executable_p "$ac_path_GREP" || continue
-# Check for GNU ac_path_GREP and select it if it is found.
-  # Check for GNU $ac_path_GREP
-case `"$ac_path_GREP" --version 2>&1` in
-*GNU*)
-  ac_cv_path_GREP="$ac_path_GREP" ac_path_GREP_found=:;;
-*)
-  ac_count=0
-  $as_echo_n 0123456789 >"conftest.in"
-  while :
-  do
-    cat "conftest.in" "conftest.in" >"conftest.tmp"
-    mv "conftest.tmp" "conftest.in"
-    cp "conftest.in" "conftest.nl"
-    $as_echo 'GREP' >> "conftest.nl"
-    "$ac_path_GREP" -e 'GREP$' -e '-(cannot match)-' < "conftest.nl" >"conftest.out" 2>/dev/null || break
-    diff "conftest.out" "conftest.nl" >/dev/null 2>&1 || break
-    as_fn_arith $ac_count + 1 && ac_count=$as_val
-    if test $ac_count -gt ${ac_path_GREP_max-0}; then
-      # Best one so far, save it but keep looking for a better one
-      ac_cv_path_GREP="$ac_path_GREP"
-      ac_path_GREP_max=$ac_count
-    fi
-    # 10*(2^10) chars as input seems more than enough
-    test $ac_count -gt 10 && break
-  done
-  rm -f conftest.in conftest.tmp conftest.nl conftest.out;;
-esac
-
-      $ac_path_GREP_found && break 3
-    done
-  done
-  done
-IFS=$as_save_IFS
-  if test -z "$ac_cv_path_GREP"; then
-    as_fn_error $? "no acceptable grep could be found in $PATH$PATH_SEPARATOR/usr/xpg4/bin" "$LINENO" 5
-  fi
-else
-  ac_cv_path_GREP=$GREP
-fi
-
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_GREP" >&5
-$as_echo "$ac_cv_path_GREP" >&6; }
- GREP="$ac_cv_path_GREP"
-
-
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for egrep" >&5
-$as_echo_n "checking for egrep... " >&6; }
-if ${ac_cv_path_EGREP+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  if echo a | $GREP -E '(a|b)' >/dev/null 2>&1
-   then ac_cv_path_EGREP="$GREP -E"
-   else
-     if test -z "$EGREP"; then
-  ac_path_EGREP_found=false
-  # Loop through the user's path and test for each of PROGNAME-LIST
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH$PATH_SEPARATOR/usr/xpg4/bin
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_prog in egrep; do
-    for ac_exec_ext in '' $ac_executable_extensions; do
-      ac_path_EGREP="$as_dir/$ac_prog$ac_exec_ext"
-      as_fn_executable_p "$ac_path_EGREP" || continue
-# Check for GNU ac_path_EGREP and select it if it is found.
-  # Check for GNU $ac_path_EGREP
-case `"$ac_path_EGREP" --version 2>&1` in
-*GNU*)
-  ac_cv_path_EGREP="$ac_path_EGREP" ac_path_EGREP_found=:;;
-*)
-  ac_count=0
-  $as_echo_n 0123456789 >"conftest.in"
-  while :
-  do
-    cat "conftest.in" "conftest.in" >"conftest.tmp"
-    mv "conftest.tmp" "conftest.in"
-    cp "conftest.in" "conftest.nl"
-    $as_echo 'EGREP' >> "conftest.nl"
-    "$ac_path_EGREP" 'EGREP$' < "conftest.nl" >"conftest.out" 2>/dev/null || break
-    diff "conftest.out" "conftest.nl" >/dev/null 2>&1 || break
-    as_fn_arith $ac_count + 1 && ac_count=$as_val
-    if test $ac_count -gt ${ac_path_EGREP_max-0}; then
-      # Best one so far, save it but keep looking for a better one
-      ac_cv_path_EGREP="$ac_path_EGREP"
-      ac_path_EGREP_max=$ac_count
-    fi
-    # 10*(2^10) chars as input seems more than enough
-    test $ac_count -gt 10 && break
-  done
-  rm -f conftest.in conftest.tmp conftest.nl conftest.out;;
-esac
-
-      $ac_path_EGREP_found && break 3
-    done
-  done
-  done
-IFS=$as_save_IFS
-  if test -z "$ac_cv_path_EGREP"; then
-    as_fn_error $? "no acceptable egrep could be found in $PATH$PATH_SEPARATOR/usr/xpg4/bin" "$LINENO" 5
-  fi
-else
-  ac_cv_path_EGREP=$EGREP
-fi
-
-   fi
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_EGREP" >&5
-$as_echo "$ac_cv_path_EGREP" >&6; }
- EGREP="$ac_cv_path_EGREP"
-
-
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for ANSI C header files" >&5
-$as_echo_n "checking for ANSI C header files... " >&6; }
-if ${ac_cv_header_stdc+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <float.h>
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  ac_cv_header_stdc=yes
-else
-  ac_cv_header_stdc=no
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-
-if test $ac_cv_header_stdc = yes; then
-  # SunOS 4.x string.h does not declare mem*, contrary to ANSI.
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <string.h>
-
-_ACEOF
-if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
-  $EGREP "memchr" >/dev/null 2>&1; then :
-
-else
-  ac_cv_header_stdc=no
-fi
-rm -f conftest*
-
-fi
-
-if test $ac_cv_header_stdc = yes; then
-  # ISC 2.0.2 stdlib.h does not declare free, contrary to ANSI.
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <stdlib.h>
-
-_ACEOF
-if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
-  $EGREP "free" >/dev/null 2>&1; then :
-
-else
-  ac_cv_header_stdc=no
-fi
-rm -f conftest*
-
-fi
-
-if test $ac_cv_header_stdc = yes; then
-  # /bin/cc in Irix-4.0.5 gets non-ANSI ctype macros unless using -ansi.
-  if test "$cross_compiling" = yes; then :
-  :
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <ctype.h>
-#include <stdlib.h>
-#if ((' ' & 0x0FF) == 0x020)
-# define ISLOWER(c) ('a' <= (c) && (c) <= 'z')
-# define TOUPPER(c) (ISLOWER(c) ? 'A' + ((c) - 'a') : (c))
-#else
-# define ISLOWER(c) \
-		   (('a' <= (c) && (c) <= 'i') \
-		     || ('j' <= (c) && (c) <= 'r') \
-		     || ('s' <= (c) && (c) <= 'z'))
-# define TOUPPER(c) (ISLOWER(c) ? ((c) | 0x40) : (c))
-#endif
-
-#define XOR(e, f) (((e) && !(f)) || (!(e) && (f)))
-int
-main ()
-{
-  int i;
-  for (i = 0; i < 256; i++)
-    if (XOR (islower (i), ISLOWER (i))
-	|| toupper (i) != TOUPPER (i))
-      return 2;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_run "$LINENO"; then :
-
-else
-  ac_cv_header_stdc=no
-fi
-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-  conftest.$ac_objext conftest.beam conftest.$ac_ext
-fi
-
-fi
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_header_stdc" >&5
-$as_echo "$ac_cv_header_stdc" >&6; }
-if test $ac_cv_header_stdc = yes; then
-
-$as_echo "#define STDC_HEADERS 1" >>confdefs.h
-
-fi
-
-# On IRIX 5.3, sys/types and inttypes.h are conflicting.
-for ac_header in sys/types.h sys/stat.h stdlib.h string.h memory.h strings.h \
-		  inttypes.h stdint.h unistd.h
-do :
-  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
-ac_fn_c_check_header_compile "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default
-"
-if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
-  cat >>confdefs.h <<_ACEOF
-#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
-_ACEOF
-
-fi
-
-done
-
-
-ac_fn_c_check_header_mongrel "$LINENO" "bfd.h" "ac_cv_header_bfd_h" "$ac_includes_default"
+  ac_fn_c_check_header_mongrel "$LINENO" "bfd.h" "ac_cv_header_bfd_h" "$ac_includes_default"
 if test "x$ac_cv_header_bfd_h" = xyes; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for bfd_openr in -lbfd" >&5
 $as_echo_n "checking for bfd_openr in -lbfd... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,9 @@ echo "  Note: mpiP sets cross_compiling to yes to keep configure from failing in
 echo "        the case where test executables would need to be run as a parallel job."
 echo
 
+AC_CHECK_SIZEOF(void*)
+
+
 #
 #  With specifications
 #

--- a/hash_proto.h
+++ b/hash_proto.h
@@ -21,6 +21,7 @@ extern int h_insert (h_t * ht, void *ptr);
 extern void *h_search (h_t * ht, void *key, void **ptr);
 extern void *h_delete (h_t * ht, void *key, void **ptr);
 extern int h_gather_data (h_t * ht, int *ac, void ***ptr);
+extern int h_drain (h_t * ht, int *ac, void ***ptr);
 
 #else /* __STDC__ */
 
@@ -31,6 +32,7 @@ extern int h_insert ( /* h_t * ht, void *ptr */ );
 extern void *h_search ( /* h_t * ht, void *key, void **ptr */ );
 extern void *h_delete ( /* h_t * ht, void *key, void **ptr */ );
 extern int h_gather_data ( /* h_t * ht, int *ac, void ***ptr */ );
+extern int h_drain ( /* h_t * ht, int *ac, void ***ptr */ );
 
 #endif /* __STDC__ */
 #endif /* __CEXTRACT__ */

--- a/make-wrappers.py
+++ b/make-wrappers.py
@@ -1052,8 +1052,11 @@ def CreateWrapper(funct, olist):
     # start wrapper code
     olist.append("\n{\n")
     olist.append( " int rc, enabledState;\n double dur;\n int tsize;\n double messSize = 0.;\n double ioSize = 0.;\n double rmaSize =0.;\n mpiPi_TIME start, end;\n void *call_stack[MPIP_CALLSITE_STACK_DEPTH_MAX] = { NULL };\n" )
+    olist.append( "  mpiPi_mt_stat_tls_t *hndl;\n" )
 
-    olist.append("\nif (mpiPi_stats_mt_is_on(&mpiPi.task_stats)) {\n")
+    olist.append("\n  hndl = mpiPi_stats_mt_gettls(&mpiPi.task_stats);\n")
+
+    olist.append("\nif (mpiPi_stats_mt_is_on(hndl)) {\n")
     if fdict[funct].wrapperPreList:
 	olist.extend(fdict[funct].wrapperPreList)
 
@@ -1067,7 +1070,7 @@ def CreateWrapper(funct, olist):
     olist.append("}\n\n")
 
     # Mark that we have already entered Profiler to avoid nested invocations
-    olist.append("mpiPi_stats_mt_enter(&mpiPi.task_stats);\n")
+    olist.append("mpiPi_stats_mt_enter(hndl);\n")
 
     # call PMPI 
     olist.append("\nrc = P" + funct + "( " )
@@ -1088,8 +1091,8 @@ def CreateWrapper(funct, olist):
     olist.append(");\n\n")
 
     # Mark that we exited Profiler
-    olist.append("mpiPi_stats_mt_exit(&mpiPi.task_stats);\n")
-    olist.append("if (mpiPi_stats_mt_is_on(&mpiPi.task_stats)) {\n")
+    olist.append("mpiPi_stats_mt_exit(hndl);\n")
+    olist.append("if (mpiPi_stats_mt_is_on(hndl)) {\n")
     olist.append("\n" 
 		 + "mpiPi_GETTIME (&end);\n" 
 		 + "dur = mpiPi_GETTIMEDIFF (&end, &start);\n")
@@ -1157,7 +1160,7 @@ def CreateWrapper(funct, olist):
 		 + "if ( dur < 0 )\n"
 		 + "  mpiPi_msg_warn(\"Rank %5d : Negative time difference : %11.9f in %s\\n\", mpiPi.rank, dur, \"" + funct + "\");\n"
 		 + "else\n")
-    olist.append( "  mpiPi_update_callsite_stats(" + "mpiPi_" + funct + ", " \
+    olist.append( "  mpiPi_update_callsite_stats(hndl, " + "mpiPi_" + funct + ", " \
                   + "mpiPi.rank, "
                   + "call_stack, "
                   + "dur, "
@@ -1169,13 +1172,13 @@ def CreateWrapper(funct, olist):
     if funct in collectiveList :
       for i in fdict[funct].paramConciseList:
 	 if (fdict[funct].paramDict[i].basetype == "MPI_Comm"):
-           olist.append("\nif (mpiPi.do_collective_stats_report) { mpiPi_update_collective_stats(" + "mpiPi_" + funct + "," \
+           olist.append("\nif (mpiPi.do_collective_stats_report) { mpiPi_update_collective_stats(hndl, " + "mpiPi_" + funct + "," \
               + " dur, " + "(double)messSize," +  " " + i + "); }\n")
 
     if funct in pt2ptList :
       for i in fdict[funct].paramConciseList:
 	 if (fdict[funct].paramDict[i].basetype == "MPI_Comm"):
-           olist.append("\nif (mpiPi.do_pt2pt_stats_report) { mpiPi_update_pt2pt_stats(" + "mpiPi_" + funct + "," \
+           olist.append("\nif (mpiPi.do_pt2pt_stats_report) { mpiPi_update_pt2pt_stats(hndl, " + "mpiPi_" + funct + "," \
               + " dur, " + "(double)messSize," +  " " + i + "); }\n")
 
     # end of enabled check

--- a/make-wrappers.py
+++ b/make-wrappers.py
@@ -1053,7 +1053,7 @@ def CreateWrapper(funct, olist):
     olist.append("\n{\n")
     olist.append( " int rc, enabledState;\n double dur;\n int tsize;\n double messSize = 0.;\n double ioSize = 0.;\n double rmaSize =0.;\n mpiPi_TIME start, end;\n void *call_stack[MPIP_CALLSITE_STACK_DEPTH_MAX] = { NULL };\n" )
 
-    olist.append("\nif (mpiPi_stats_thr_is_on(&mpiPi.task_stats)) {\n")
+    olist.append("\nif (mpiPi_stats_mt_is_on(&mpiPi.task_stats)) {\n")
     if fdict[funct].wrapperPreList:
 	olist.extend(fdict[funct].wrapperPreList)
 
@@ -1067,7 +1067,7 @@ def CreateWrapper(funct, olist):
     olist.append("}\n\n")
 
     # Mark that we have already entered Profiler to avoid nested invocations
-    olist.append("mpiPi_stats_thr_enter(&mpiPi.task_stats);\n")
+    olist.append("mpiPi_stats_mt_enter(&mpiPi.task_stats);\n")
 
     # call PMPI 
     olist.append("\nrc = P" + funct + "( " )
@@ -1088,8 +1088,8 @@ def CreateWrapper(funct, olist):
     olist.append(");\n\n")
 
     # Mark that we exited Profiler
-    olist.append("mpiPi_stats_thr_exit(&mpiPi.task_stats);\n")
-    olist.append("if (mpiPi_stats_thr_is_on(&mpiPi.task_stats)) {\n")
+    olist.append("mpiPi_stats_mt_exit(&mpiPi.task_stats);\n")
+    olist.append("if (mpiPi_stats_mt_is_on(&mpiPi.task_stats)) {\n")
     olist.append("\n" 
 		 + "mpiPi_GETTIME (&end);\n" 
 		 + "dur = mpiPi_GETTIMEDIFF (&end, &start);\n")

--- a/mpiP-callsites.c
+++ b/mpiP-callsites.c
@@ -1,0 +1,432 @@
+/* -*- C -*-
+
+   mpiP MPI Profiler ( http://llnl.github.io/mpiP )
+
+   Please see COPYRIGHT AND LICENSE information at the end of this file.
+
+   -----
+
+   hash.h -- generic hash table
+
+   $Id$
+
+*/
+
+#include <string.h>
+#include "mpiP-callsites.h"
+#include "mpiPi.h"
+
+void mpiPi_cs_reset_stat(callsite_stats_t *csp)
+{
+  csp->maxDur = 0;
+  csp->minDur = DBL_MAX;
+  csp->maxIO = 0;
+  csp->minIO = DBL_MAX;
+  csp->maxDataSent = 0;
+  csp->minDataSent = DBL_MAX;
+
+  csp->count = 0;
+  csp->cumulativeTime = 0;
+  csp->cumulativeTimeSquared = 0;
+  csp->cumulativeDataSent = 0;
+  csp->cumulativeIO = 0;
+
+  csp->arbitraryMessageCount = 0;
+}
+
+void mpiPi_cs_init(callsite_stats_t *csp, void *pc[],
+                   unsigned op, unsigned rank)
+{
+  int i;
+  csp->op = op;
+  csp->rank = rank;
+  for (i = 0; i < MPIP_CALLSITE_STACK_DEPTH; i++)
+    {
+      csp->pc[i] = pc[i];
+    }
+  csp->cookie = MPIP_CALLSITE_STATS_COOKIE;
+  mpiPi_cs_reset_stat(csp);
+}
+
+void mpiPi_cs_update(callsite_stats_t *csp, double dur,
+                     double sendSize, double ioSize, double rmaSize,
+                     double threshold)
+{
+  csp->count++;
+  csp->cumulativeTime += dur;
+  assert (csp->cumulativeTime >= 0);
+  csp->cumulativeTimeSquared += (dur * dur);
+  assert (csp->cumulativeTimeSquared >= 0);
+  csp->maxDur = max (csp->maxDur, dur);
+  csp->minDur = min (csp->minDur, dur);
+  csp->cumulativeDataSent += sendSize;
+  csp->cumulativeIO += ioSize;
+  csp->cumulativeRMA += rmaSize;
+
+  csp->maxDataSent = max (csp->maxDataSent, sendSize);
+  csp->minDataSent = min (csp->minDataSent, sendSize);
+
+  csp->maxIO = max (csp->maxIO, ioSize);
+  csp->minIO = min (csp->minIO, ioSize);
+
+  csp->maxRMA = max (csp->maxRMA, rmaSize);
+  csp->minRMA = min (csp->minRMA, rmaSize);
+
+  if (threshold > -1 && (sendSize >= threshold))
+    csp->arbitraryMessageCount++;
+}
+
+
+/* Callsite statistics */
+void mpiPi_cs_merge(callsite_stats_t *dst, callsite_stats_t *src)
+{
+  dst->count += src->count;
+  dst->cumulativeTime += src->cumulativeTime;
+  assert (dst->cumulativeTime >= 0);
+  dst->cumulativeTimeSquared += src->cumulativeTimeSquared;
+  assert (dst->cumulativeTimeSquared >= 0);
+  dst->maxDur = max (dst->maxDur, src->maxDur);
+  dst->minDur = min (dst->minDur, src->minDur);
+  dst->maxDataSent = max (dst->maxDataSent, src->maxDataSent);
+  dst->minDataSent = min (dst->minDataSent, src->minDataSent);
+  dst->cumulativeDataSent += src->cumulativeDataSent;
+  dst->maxIO = max (dst->maxIO, src->maxIO);
+  dst->minIO = min (dst->minIO, src->minIO);
+  dst->cumulativeIO += src->cumulativeIO;
+  dst->cumulativeRMA += src->cumulativeRMA;
+  dst->arbitraryMessageCount += src->arbitraryMessageCount;
+}
+
+/*
+ * ============================================================================
+ *
+ * Program counter (PC) to source code id: File/Function/Line
+ *
+ * ============================================================================
+ */
+
+typedef struct callsite_cache_entry_t
+{
+  void *pc;
+  char *filename;
+  char *functname;
+  int line;
+}
+callsite_pc_cache_entry_t;
+
+h_t *callsite_pc_cache = NULL;
+h_t *callsite_src_id_cache = NULL;
+int callsite_src_id_counter = 1;
+
+static int
+callsite_pc_cache_comparator (const void *p1, const void *p2)
+{
+  callsite_pc_cache_entry_t *cs1 = (callsite_pc_cache_entry_t *) p1;
+  callsite_pc_cache_entry_t *cs2 = (callsite_pc_cache_entry_t *) p2;
+
+  if ((long) cs1->pc > (long) cs2->pc)
+    {
+      return 1;
+    }
+  if ((long) cs1->pc < (long) cs2->pc)
+    {
+      return -1;
+    }
+  return 0;
+}
+
+static int
+callsite_pc_cache_hashkey (const void *p1)
+{
+  callsite_pc_cache_entry_t *cs1 = (callsite_pc_cache_entry_t *) p1;
+  return 662917 ^ ((long) cs1->pc);
+}
+
+static int
+callsite_src_id_cache_comparator (const void *p1, const void *p2)
+{
+  int i;
+  callsite_src_id_cache_entry_t *csp_1 = (callsite_src_id_cache_entry_t *) p1;
+  callsite_src_id_cache_entry_t *csp_2 = (callsite_src_id_cache_entry_t *) p2;
+
+#define express(f) {if ((csp_1->f) > (csp_2->f)) {return 1;} if ((csp_1->f) < (csp_2->f)) {return -1;}}
+  if (mpiPi.stackDepth == 0)
+    {
+      express (id);		/* In cases where the call stack depth is 0, the only unique info may be the id */
+      return 0;
+    }
+  else
+    {
+      for (i = 0; i < MPIP_CALLSITE_STACK_DEPTH; i++)
+        {
+          if (csp_1->filename[i] != NULL && csp_2->filename[i] != NULL)
+            {
+              if (strcmp (csp_1->filename[i], csp_2->filename[i]) > 0)
+                {
+                  return 1;
+                }
+              if (strcmp (csp_1->filename[i], csp_2->filename[i]) < 0)
+                {
+                  return -1;
+                }
+              express (line[i]);
+              if (strcmp (csp_1->functname[i], csp_2->functname[i]) > 0)
+                {
+                  return 1;
+                }
+              if (strcmp (csp_1->functname[i], csp_2->functname[i]) < 0)
+                {
+                  return -1;
+                }
+            }
+
+          express (pc[i]);
+        }
+    }
+#undef express
+  return 0;
+}
+
+static int
+callsite_src_id_cache_hashkey (const void *p1)
+{
+  int i, j;
+  int res = 0;
+  callsite_src_id_cache_entry_t *cs1 = (callsite_src_id_cache_entry_t *) p1;
+  for (i = 0; i < MPIP_CALLSITE_STACK_DEPTH; i++)
+    {
+      if (cs1->filename[i] != NULL)
+        {
+          for (j = 0; cs1->filename[i][j] != '\0'; j++)
+            {
+              res ^= (unsigned) cs1->filename[i][j];
+            }
+          for (j = 0; cs1->functname[i][j] != '\0'; j++)
+            {
+              res ^= (unsigned) cs1->functname[i][j];
+            }
+        }
+      res ^= cs1->line[i];
+    }
+  return 662917 ^ res;
+}
+
+void mpiPi_cs_cache_init()
+{
+  if (callsite_pc_cache == NULL)
+    {
+      callsite_pc_cache = h_open (mpiPi.tableSize,
+                                  callsite_pc_cache_hashkey,
+                                  callsite_pc_cache_comparator);
+    }
+  if (callsite_src_id_cache == NULL)
+    {
+      callsite_src_id_cache = h_open (mpiPi.tableSize,
+                                      callsite_src_id_cache_hashkey,
+                                      callsite_src_id_cache_comparator);
+    }
+}
+
+int
+mpiPi_query_pc (void *pc, char **filename, char **functname, int *lineno)
+{
+  int rc = 0;
+  callsite_pc_cache_entry_t key;
+  callsite_pc_cache_entry_t *csp;
+  char addr_buf[24];
+
+  key.pc = pc;
+  /* do we have a cache entry for this pc? If so, use entry */
+  if (h_search (callsite_pc_cache, &key, (void **) &csp) == NULL)
+    {
+      /* no cache entry: create, lookup, and insert */
+      csp =
+          (callsite_pc_cache_entry_t *)
+          malloc (sizeof (callsite_pc_cache_entry_t));
+      csp->pc = pc;
+#if defined(ENABLE_BFD) || defined(USE_LIBDWARF)
+      if (mpiP_find_src_loc (pc, filename, lineno, functname) == 0)
+        {
+          if (*filename == NULL || strcmp (*filename, "??") == 0)
+            *filename = "[unknown]";
+
+          if (*functname == NULL)
+            *functname = "[unknown]";
+
+          mpiPi_msg_debug
+              ("Successful Source lookup for [%s]: %s, %d, %s\n",
+               mpiP_format_address (pc, addr_buf), *filename, *lineno,
+               *functname);
+
+          csp->filename = strdup (*filename);
+          csp->functname = strdup (*functname);
+          csp->line = *lineno;
+        }
+      else
+        {
+          mpiPi_msg_debug ("Unsuccessful Source lookup for [%s]\n",
+                           mpiP_format_address (pc, addr_buf));
+          csp->filename = strdup ("[unknown]");
+          csp->functname = strdup ("[unknown]");
+          csp->line = 0;
+        }
+#else /* ! ENABLE_BFD || USE_LIBDWARF */
+      csp->filename = strdup ("[unknown]");
+      csp->functname = strdup ("[unknown]");
+      csp->line = 0;
+#endif
+      h_insert (callsite_pc_cache, csp);
+    }
+
+  *filename = csp->filename;
+  *functname = csp->functname;
+  *lineno = csp->line;
+
+  if (*lineno == 0)
+    rc = 1;			/* use this value to indicate a failed lookup */
+
+  return rc;
+}
+
+/* take a callstats record (the pc) and determine src file, line, if
+   possible and assign a callsite id.
+ */
+int
+mpiPi_query_src (callsite_stats_t * p)
+{
+  int i;
+  callsite_src_id_cache_entry_t key;
+  callsite_src_id_cache_entry_t *csp;
+  assert (p);
+
+  /* Because multiple pcs can map to the same source line, we must
+     check that mapping here. If we got unknown, then we assign
+     different ids */
+  bzero (&key, sizeof (callsite_src_id_cache_entry_t));
+
+  for (i = 0; (i < MPIP_CALLSITE_STACK_DEPTH) && (p->pc[i] != NULL); i++)
+    {
+      if (mpiPi.do_lookup == 1)
+        mpiPi_query_pc (p->pc[i], &(p->filename[i]), &(p->functname[i]),
+                        &(p->lineno[i]));
+      else
+        {
+          p->filename[i] = strdup ("[unknown]");
+          p->functname[i] = strdup ("[unknown]");
+          p->lineno[i] = 0;
+        }
+
+      key.filename[i] = p->filename[i];
+      key.functname[i] = p->functname[i];
+      key.line[i] = p->lineno[i];
+      key.pc[i] = p->pc[i];
+    }
+
+  /* MPI ID is compared when stack depth is 0 */
+  key.id = p->op - mpiPi_BASE;
+
+  /* lookup/generate an ID based on the callstack, not just the callsite pc */
+  if (h_search (callsite_src_id_cache, &key, (void **) &csp) == NULL)
+    {
+      /* create a new entry, and assign an id based on callstack */
+      csp =
+          (callsite_src_id_cache_entry_t *)
+          malloc (sizeof (callsite_src_id_cache_entry_t));
+      bzero (csp, sizeof (callsite_src_id_cache_entry_t));
+
+      for (i = 0; (i < MPIP_CALLSITE_STACK_DEPTH) && (p->pc[i] != NULL); i++)
+        {
+          csp->filename[i] = strdup (key.filename[i]);
+          csp->functname[i] = strdup (key.functname[i]);
+          csp->line[i] = key.line[i];
+          csp->pc[i] = p->pc[i];
+        }
+      csp->op = p->op;
+      if (mpiPi.stackDepth == 0)
+        csp->id = csp->op - mpiPi_BASE;
+      else
+        csp->id = callsite_src_id_counter++;
+      h_insert (callsite_src_id_cache, csp);
+    }
+
+  /* assign ID to this record */
+  p->csid = csp->id;
+
+  return p->csid;
+}
+
+/*
+
+  <license>
+
+  Copyright (c) 2006, The Regents of the University of California.
+  Produced at the Lawrence Livermore National Laboratory
+  Written by Jeffery Vetter and Christopher Chambreau.
+  UCRL-CODE-223450.
+  All rights reserved.
+
+  Copyright (c) 2019, Mellanox Technologies Inc.
+  Written by Artem Polyakov
+  All rights reserved.
+
+
+  This file is part of mpiP.  For details, see http://llnl.github.io/mpiP.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+
+  * Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the disclaimer below.
+
+  * Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the disclaimer (as noted below) in
+  the documentation and/or other materials provided with the
+  distribution.
+
+  * Neither the name of the UC/LLNL nor the names of its contributors
+  may be used to endorse or promote products derived from this software
+  without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OF
+  THE UNIVERSITY OF CALIFORNIA, THE U.S. DEPARTMENT OF ENERGY OR
+  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+  Additional BSD Notice
+
+  1. This notice is required to be provided under our contract with the
+  U.S. Department of Energy (DOE).  This work was produced at the
+  University of California, Lawrence Livermore National Laboratory under
+  Contract No. W-7405-ENG-48 with the DOE.
+
+  2. Neither the United States Government nor the University of
+  California nor any of their employees, makes any warranty, express or
+  implied, or assumes any liability or responsibility for the accuracy,
+  completeness, or usefulness of any information, apparatus, product, or
+  process disclosed, or represents that its use would not infringe
+  privately-owned rights.
+
+  3.  Also, reference herein to any specific commercial products,
+  process, or services by trade name, trademark, manufacturer or
+  otherwise does not necessarily constitute or imply its endorsement,
+  recommendation, or favoring by the United States Government or the
+  University of California.  The views and opinions of authors expressed
+  herein do not necessarily state or reflect those of the United States
+  Government or the University of California, and shall not be used for
+  advertising or product endorsement purposes.
+
+  </license>
+
+*/
+
+/* EOF */

--- a/mpiP-callsites.h
+++ b/mpiP-callsites.h
@@ -1,0 +1,147 @@
+/* -*- C -*-
+
+   mpiP MPI Profiler ( http://llnl.github.io/mpiP )
+
+   Please see COPYRIGHT AND LICENSE information at the end of this file.
+
+   -----
+
+   hash.h -- generic hash table
+
+   $Id$
+
+*/
+
+#ifndef MPIPCALLSITES_H
+#define MPIPCALLSITES_H
+
+#include "mpiPconfig.h"
+
+/* Callsite statistics */
+typedef struct _callsite_stats
+{
+  unsigned op;
+  unsigned rank;
+  int csid;
+  long long count;
+  double cumulativeTime;
+  double cumulativeTimeSquared;
+  double maxDur;
+  double minDur;
+  double maxDataSent;
+  double minDataSent;
+  double maxIO;
+  double minIO;
+  double maxRMA;
+  double minRMA;
+  double cumulativeDataSent;
+  double cumulativeIO;
+  double cumulativeRMA;
+  long long arbitraryMessageCount;
+  double *siteData;
+  int siteDataIdx;
+  void *pc[MPIP_CALLSITE_STACK_DEPTH_MAX];
+  char *filename[MPIP_CALLSITE_STACK_DEPTH_MAX];
+  char *functname[MPIP_CALLSITE_STACK_DEPTH_MAX];
+  int lineno[MPIP_CALLSITE_STACK_DEPTH_MAX];
+  long cookie;
+} callsite_stats_t;
+
+
+/*
+ * Simple callsite structure management routines
+ */
+void mpiPi_cs_init(callsite_stats_t *csp, void *pc[],
+                   unsigned op, unsigned rank);
+void mpiPi_cs_reset_stat(callsite_stats_t *csp);
+void mpiPi_cs_merge(callsite_stats_t *dst, callsite_stats_t *src);
+void mpiPi_cs_update(callsite_stats_t *csp, double dur,
+                     double sendSize, double ioSize, double rmaSize,
+                     double threshold);
+
+/*
+ * Callsite caching
+ */
+void mpiPi_cs_cache_init();
+/* Translate callstats record (the pc) to src file, line and assign a
+ * callsite id.
+ */
+int mpiPi_query_src (callsite_stats_t * p);
+
+#endif // MPIPCALLSITES_H
+
+/*
+
+  <license>
+
+  Copyright (c) 2006, The Regents of the University of California.
+  Produced at the Lawrence Livermore National Laboratory
+  Written by Jeffery Vetter and Christopher Chambreau.
+  UCRL-CODE-223450.
+  All rights reserved.
+
+  Copyright (c) 2019, Mellanox Technologies Inc.
+  Written by Artem Polyakov
+  All rights reserved.
+
+
+  This file is part of mpiP.  For details, see http://llnl.github.io/mpiP.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+
+  * Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the disclaimer below.
+
+  * Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the disclaimer (as noted below) in
+  the documentation and/or other materials provided with the
+  distribution.
+
+  * Neither the name of the UC/LLNL nor the names of its contributors
+  may be used to endorse or promote products derived from this software
+  without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OF
+  THE UNIVERSITY OF CALIFORNIA, THE U.S. DEPARTMENT OF ENERGY OR
+  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+  Additional BSD Notice
+
+  1. This notice is required to be provided under our contract with the
+  U.S. Department of Energy (DOE).  This work was produced at the
+  University of California, Lawrence Livermore National Laboratory under
+  Contract No. W-7405-ENG-48 with the DOE.
+
+  2. Neither the United States Government nor the University of
+  California nor any of their employees, makes any warranty, express or
+  implied, or assumes any liability or responsibility for the accuracy,
+  completeness, or usefulness of any information, apparatus, product, or
+  process disclosed, or represents that its use would not infringe
+  privately-owned rights.
+
+  3.  Also, reference herein to any specific commercial products,
+  process, or services by trade name, trademark, manufacturer or
+  otherwise does not necessarily constitute or imply its endorsement,
+  recommendation, or favoring by the United States Government or the
+  University of California.  The views and opinions of authors expressed
+  herein do not necessarily state or reflect those of the United States
+  Government or the University of California, and shall not be used for
+  advertising or product endorsement purposes.
+
+  </license>
+
+*/
+
+/* EOF */

--- a/mpiP-hash.c
+++ b/mpiP-hash.c
@@ -205,6 +205,30 @@ h_gather_data (h_t * ht, int *ac, void ***ptr)
   return *ac;
 }
 
+int
+h_drain (h_t * ht, int *ac, void ***ptr)
+{
+  int i;
+  h_entry_t *het_index = NULL;
+  h_gather_data (ht, ac, ptr);
+
+  for (i = 0; i < ht->size; i++)
+    {
+      if (ht->table[i] != NULL)
+        {
+          for (het_index = ht->table[i];
+               het_index != NULL; )
+            {
+              h_entry_t *to_free = het_index;
+              het_index = het_index->next;
+              free(to_free);
+            }
+        }
+      ht->table[i] = NULL;
+    }
+  ht->count = 0;
+  return *ac;
+}
 
 #define TESTING 0
 #if TESTING

--- a/mpiP-hash.c
+++ b/mpiP-hash.c
@@ -115,8 +115,6 @@ h_search (h_t * ht, void *key, void **ptr)
   unsigned tableIndex;
   h_entry_t *het_index = NULL;
   if (ht == NULL){
-      int delay = 1;
-      while(delay) { sleep(1); }
     Abort ("hash table uninitialized");
     }
   if (key == NULL)

--- a/mpiP-mt-stats.c
+++ b/mpiP-mt-stats.c
@@ -1,0 +1,98 @@
+#include "mpiP-stats.h"
+#include "mpiP-mt-stats.h"
+
+int mpiPi_stats_mt_init(mpiPi_mt_stat_t *stat)
+{
+  mpiPi_stats_thr_init(&stat->st_stat);
+}
+void mpiPi_stats_mt_fini(mpiPi_mt_stat_t *stat)
+{
+  mpiPi_stats_thr_fini(&stat->st_stat);
+}
+
+void mpiPi_stats_mt_cs_gather(mpiPi_mt_stat_t *stat,
+                             int *ac, callsite_stats_t ***av )
+{
+  mpiPi_stats_thr_cs_gather(&stat->st_stat, ac, av);
+}
+
+void mpiPi_stats_mt_cs_upd (mpiPi_mt_stat_t *stat,
+                           unsigned op, unsigned rank, void **pc,
+                           double dur, double sendSize, double ioSize,
+                           double rmaSize)
+{
+  mpiPi_stats_thr_cs_upd(&stat->st_stat,
+                         op, rank, pc, dur,
+                         sendSize, ioSize, rmaSize);
+}
+
+void mpiPi_stats_mt_cs_lookup(mpiPi_mt_stat_t *stat,
+                              callsite_stats_t *task_stats,
+                              callsite_stats_t **task_lookup,
+                              callsite_stats_t *dummy_buf,
+                              int initMax)
+{
+  mpiPi_stats_thr_cs_lookup(&stat->st_stat, task_stats, task_lookup,
+                            dummy_buf, initMax);
+}
+
+void mpiPi_stats_mt_coll_upd(mpiPi_mt_stat_t *stat,
+                                  int op, double dur, double size,
+                                  MPI_Comm * comm)
+{
+  mpiPi_stats_thr_coll_upd(&stat->st_stat, op, dur, size, comm);
+}
+
+void mpiPi_stats_mt_coll_gather(mpiPi_mt_stat_t *stat, double **_outbuf)
+{
+  mpiPi_stats_thr_coll_gather(&stat->st_stat, _outbuf);
+}
+
+void mpiPi_stats_mt_cs_reset(mpiPi_mt_stat_t *stat)
+{
+  mpiPi_stats_thr_cs_reset(&stat->st_stat);
+}
+
+void mpiPi_stats_mt_coll_binstrings(mpiPi_mt_stat_t *stat,
+                                     int comm_idx, char *comm_buf,
+                                     int size_idx, char *size_buf)
+{
+  mpiPi_stats_thr_coll_binstrings(&stat->st_stat,
+                                  comm_idx, comm_buf,
+                                  size_idx, size_buf);
+}
+
+void mpiPi_stats_mt_pt2pt_upd (mpiPi_mt_stat_t *stat,
+                                   int op, double dur, double size,
+                                   MPI_Comm * comm)
+{
+  mpiPi_stats_thr_pt2pt_upd(&stat->st_stat, op, dur, size, comm);
+}
+
+void mpiPi_stats_mt_pt2pt_gather(mpiPi_mt_stat_t *stat, double **_outbuf)
+{
+  mpiPi_stats_thr_pt2pt_gather(&stat->st_stat, _outbuf);
+}
+
+void mpiPi_stats_mt_pt2pt_binstrings(mpiPi_mt_stat_t *stat,
+                                     int comm_idx, char *comm_buf,
+                                     int size_idx, char *size_buf)
+{
+  mpiPi_stats_thr_pt2pt_binstrings(&stat->st_stat, comm_idx, comm_buf,
+                                   size_idx, size_buf);
+}
+
+int mpiPi_stats_mt_exit(mpiPi_mt_stat_t *stat)
+{
+  mpiPi_stats_thr_exit(&stat->st_stat);
+}
+
+int mpiPi_stats_mt_enter(mpiPi_mt_stat_t *stat)
+{
+  mpiPi_stats_thr_enter(&stat->st_stat);
+}
+
+int mpiPi_stats_mt_is_on(mpiPi_mt_stat_t *stat)
+{
+  mpiPi_stats_thr_is_on(&stat->st_stat);
+}

--- a/mpiP-mt-stats.c
+++ b/mpiP-mt-stats.c
@@ -1,28 +1,137 @@
+#include "mpiPi.h"
 #include "mpiP-stats.h"
 #include "mpiP-mt-stats.h"
+#include "mpiPi_proto.h"
 
-int mpiPi_stats_mt_init(mpiPi_mt_stat_t *stat)
+/*
+ * ============================================================================
+ *
+ * Multi-thread management code
+ *
+ * ============================================================================
+ */
+
+static void key_destruct(void *data)
 {
-  mpiPi_stats_thr_init(&stat->st_stat);
-}
-void mpiPi_stats_mt_fini(mpiPi_mt_stat_t *stat)
-{
-  mpiPi_stats_thr_fini(&stat->st_stat);
+  mpiPi_thread_stat_t *stat = (mpiPi_thread_stat_t *)data;
+  /* TODO: do we need to do anything here? */
 }
 
-void mpiPi_stats_mt_cs_gather(mpiPi_mt_stat_t *stat,
+static inline mpiPi_thread_stat_t *
+_get_local_tls(mpiPi_mt_stat_t *mt_state)
+{
+  mpiPi_thread_stat_t *st_state;
+
+  if (MPIPI_MODE_ST == mt_state->mode)
+    {
+      /* For all non-MPI_THREAD_MULTIPLE modes use
+       * embedded data structure
+       */
+      st_state = &mt_state->rank_stats;
+    } else {
+      /* For the MPI_THREAD_MULTIPLE mode use TLS
+       */
+      st_state = pthread_getspecific(mt_state->tls_this);
+      if (NULL == st_state)
+        {
+          st_state = malloc(sizeof(mpiPi_thread_stat_t));
+          if (NULL == st_state) {
+              mpiPi_abort("failed to allocate TLS");
+            }
+          (void) pthread_setspecific(mt_state->tls_this, st_state);
+          mpiPi_stats_thr_init(st_state);
+          mpiPi_tslist_append(mt_state->tls_list, st_state);
+        }
+    }
+  return st_state;
+}
+
+static void _merge_mt_stat(mpiPi_mt_stat_t *mt_state)
+{
+
+}
+
+
+/*
+ * ============================================================================
+ *
+ * Multi-threaded layer
+ *
+ * ============================================================================
+ */
+
+int mpiPi_stats_mt_init(mpiPi_mt_stat_t *mt_state, mpiPi_thr_mode_t mode)
+{
+  mt_state->mode = mode;
+  mpiPi_stats_thr_init(&mt_state->rank_stats);
+  switch(mt_state->mode) {
+    case MPIPI_MODE_MT:
+      mt_state->tls_list = mpiPi_tslist_create();
+      pthread_key_create(&mt_state->tls_this, key_destruct);
+    default:
+      break;
+    }
+  return 0;
+}
+
+void mpiPi_stats_mt_fini(mpiPi_mt_stat_t *mt_state)
+{
+  switch(mt_state->mode)
+    {
+    case MPIPI_MODE_ST:
+      mpiPi_stats_thr_fini(&mt_state->rank_stats);
+      break;
+    case MPIPI_MODE_MT:
+      // TODO: Make sure that list is drained
+      mpiPi_tslist_release(mt_state->tls_list);
+      pthread_key_delete(mt_state->tls_this);
+      mpiPi_stats_thr_init(&mt_state->rank_stats);
+      break;
+    }
+}
+
+void mpiPi_stats_mt_merge(mpiPi_mt_stat_t *mt_state)
+{
+  mpiP_tslist_elem_t *curr = NULL;
+
+  if(MPIPI_MODE_ST == mt_state->mode) {
+      /* Nothing to do here */
+      return;
+    }
+  curr = mpiPi_tslist_first(mt_state->tls_list);
+
+  mpiPi_stats_thr_cs_reset(&mt_state->rank_stats);
+
+  /* Go over all TLS structures and merge them into the rank-wide callsite info */
+  while (curr)
+    {
+      mpiPi_stats_thr_merge_all(&mt_state->rank_stats, curr->ptr);
+      curr = mpiPi_tslist_next(curr);
+    }
+}
+
+void mpiPi_stats_mt_cs_gather(mpiPi_mt_stat_t *mt_state,
                              int *ac, callsite_stats_t ***av )
 {
-  mpiPi_stats_thr_cs_gather(&stat->st_stat, ac, av);
+  switch(mt_state->mode)
+    {
+    case MPIPI_MODE_ST:
+      mpiPi_stats_thr_cs_gather(&mt_state->rank_stats, ac, av);
+      break;
+    case MPIPI_MODE_MT:
+      mpiPi_stats_thr_cs_gather(&mt_state->rank_stats, ac, av);
+      break;
+    }
 }
 
-void mpiPi_stats_mt_cs_upd (mpiPi_mt_stat_t *stat,
+void mpiPi_stats_mt_cs_upd (mpiPi_mt_stat_t *mt_state,
                            unsigned op, unsigned rank, void **pc,
                            double dur, double sendSize, double ioSize,
                            double rmaSize)
 {
-  mpiPi_stats_thr_cs_upd(&stat->st_stat,
-                         op, rank, pc, dur,
+  mpiPi_thread_stat_t *st_state = NULL;
+  st_state = _get_local_tls(mt_state);
+  mpiPi_stats_thr_cs_upd(st_state, op, rank, pc, dur,
                          sendSize, ioSize, rmaSize);
 }
 
@@ -32,67 +141,77 @@ void mpiPi_stats_mt_cs_lookup(mpiPi_mt_stat_t *stat,
                               callsite_stats_t *dummy_buf,
                               int initMax)
 {
-  mpiPi_stats_thr_cs_lookup(&stat->st_stat, task_stats, task_lookup,
+  mpiPi_stats_thr_cs_lookup(&stat->rank_stats, task_stats, task_lookup,
                             dummy_buf, initMax);
 }
 
-void mpiPi_stats_mt_coll_upd(mpiPi_mt_stat_t *stat,
+void mpiPi_stats_mt_coll_upd(mpiPi_mt_stat_t *mt_state,
                                   int op, double dur, double size,
                                   MPI_Comm * comm)
 {
-  mpiPi_stats_thr_coll_upd(&stat->st_stat, op, dur, size, comm);
+  mpiPi_thread_stat_t *st_state;
+  st_state = _get_local_tls(mt_state);
+  mpiPi_stats_thr_coll_upd(st_state, op, dur, size, comm);
 }
 
 void mpiPi_stats_mt_coll_gather(mpiPi_mt_stat_t *stat, double **_outbuf)
 {
-  mpiPi_stats_thr_coll_gather(&stat->st_stat, _outbuf);
+  mpiPi_stats_thr_coll_gather(&stat->rank_stats, _outbuf);
 }
 
 void mpiPi_stats_mt_cs_reset(mpiPi_mt_stat_t *stat)
 {
-  mpiPi_stats_thr_cs_reset(&stat->st_stat);
+  mpiPi_stats_thr_cs_reset(&stat->rank_stats);
 }
 
 void mpiPi_stats_mt_coll_binstrings(mpiPi_mt_stat_t *stat,
                                      int comm_idx, char *comm_buf,
                                      int size_idx, char *size_buf)
 {
-  mpiPi_stats_thr_coll_binstrings(&stat->st_stat,
+  mpiPi_stats_thr_coll_binstrings(&stat->rank_stats,
                                   comm_idx, comm_buf,
                                   size_idx, size_buf);
 }
 
-void mpiPi_stats_mt_pt2pt_upd (mpiPi_mt_stat_t *stat,
+void mpiPi_stats_mt_pt2pt_upd (mpiPi_mt_stat_t *mt_state,
                                    int op, double dur, double size,
                                    MPI_Comm * comm)
 {
-  mpiPi_stats_thr_pt2pt_upd(&stat->st_stat, op, dur, size, comm);
+  mpiPi_thread_stat_t *st_state;
+  st_state = _get_local_tls(mt_state);
+  mpiPi_stats_thr_pt2pt_upd(st_state, op, dur, size, comm);
 }
 
 void mpiPi_stats_mt_pt2pt_gather(mpiPi_mt_stat_t *stat, double **_outbuf)
 {
-  mpiPi_stats_thr_pt2pt_gather(&stat->st_stat, _outbuf);
+  mpiPi_stats_thr_pt2pt_gather(&stat->rank_stats, _outbuf);
 }
 
 void mpiPi_stats_mt_pt2pt_binstrings(mpiPi_mt_stat_t *stat,
                                      int comm_idx, char *comm_buf,
                                      int size_idx, char *size_buf)
 {
-  mpiPi_stats_thr_pt2pt_binstrings(&stat->st_stat, comm_idx, comm_buf,
+  mpiPi_stats_thr_pt2pt_binstrings(&stat->rank_stats, comm_idx, comm_buf,
                                    size_idx, size_buf);
 }
 
-int mpiPi_stats_mt_exit(mpiPi_mt_stat_t *stat)
+int mpiPi_stats_mt_exit(mpiPi_mt_stat_t *mt_state)
 {
-  mpiPi_stats_thr_exit(&stat->st_stat);
+  mpiPi_thread_stat_t *st_state;
+  st_state = _get_local_tls(mt_state);
+  mpiPi_stats_thr_exit(st_state);
 }
 
-int mpiPi_stats_mt_enter(mpiPi_mt_stat_t *stat)
+int mpiPi_stats_mt_enter(mpiPi_mt_stat_t *mt_state)
 {
-  mpiPi_stats_thr_enter(&stat->st_stat);
+  mpiPi_thread_stat_t *st_state;
+  st_state = _get_local_tls(mt_state);
+  mpiPi_stats_thr_enter(st_state);
 }
 
-int mpiPi_stats_mt_is_on(mpiPi_mt_stat_t *stat)
+int mpiPi_stats_mt_is_on(mpiPi_mt_stat_t *mt_state)
 {
-  mpiPi_stats_thr_is_on(&stat->st_stat);
+  mpiPi_thread_stat_t *st_state;
+  st_state = _get_local_tls(mt_state);
+  mpiPi_stats_thr_is_on(st_state);
 }

--- a/mpiP-mt-stats.h
+++ b/mpiP-mt-stats.h
@@ -1,161 +1,81 @@
-/* -*- C -*- 
+#ifndef MPIPMTSTATS_H
+#define MPIPMTSTATS_H
 
-   mpiP MPI Profiler ( http://llnl.github.io/mpiP )
-
-   Please see COPYRIGHT AND LICENSE information at the end of this file.
-
-   ----- 
-
-   hash.h -- generic hash table
-
-   $Id$
-
-*/
-
-#ifndef _MPIP_STATS_H
-#define _MPIP_STATS_H
-
-#include <mpi.h>
-#include <float.h>
-#include "mpiPconfig.h"
-#include "mpiP-hash.h"
-#include "mpiPi_def.h"
-
-
-/* Histograms */
-typedef struct _mpiPi_histogram
-{
-  int first_bin_max;
-  int hist_size;
-  int *bin_intervals;
-} mpiPi_histogram_t;
-
-/* Callsite statistics */
-typedef struct _callsite_stats
-{
-  unsigned op;
-  unsigned rank;
-  int csid;
-  long long count;
-  double cumulativeTime;
-  double cumulativeTimeSquared;
-  double maxDur;
-  double minDur;
-  double maxDataSent;
-  double minDataSent;
-  double maxIO;
-  double minIO;
-  double maxRMA;
-  double minRMA;
-  double cumulativeDataSent;
-  double cumulativeIO;
-  double cumulativeRMA;
-  long long arbitraryMessageCount;
-  double *siteData;
-  int siteDataIdx;
-  void *pc[MPIP_CALLSITE_STACK_DEPTH_MAX];
-  char *filename[MPIP_CALLSITE_STACK_DEPTH_MAX];
-  char *functname[MPIP_CALLSITE_STACK_DEPTH_MAX];
-  int lineno[MPIP_CALLSITE_STACK_DEPTH_MAX];
-  long cookie;
-} callsite_stats_t;
-
-/* Message/Communicator statistics */
-#define MPIP_NFUNC (mpiPi_DEF_END - mpiPi_BASE)
-#define MPIP_COMM_HISTCNT 32
-#define MPIP_SIZE_HISTCNT 32
-typedef struct {
-  /* Collectives statistics */
-  mpiPi_histogram_t comm_hist;
-  mpiPi_histogram_t size_hist;
-  double time_stats[MPIP_NFUNC][MPIP_COMM_HISTCNT][MPIP_SIZE_HISTCNT];
-} mpiPi_msg_stat_t;
+#include "mpiP-stats.h"
 
 /* Per-thread MPI status */
 typedef struct {
-  /* Avoid double-measurement when MPI functions are
-   * invoked internally e.g. in collectives
-   */
-  int disabled;
+  union {
+    mpiPi_thread_stat_t st_stat;
+  };
+} mpiPi_mt_stat_t;
 
-  /* Callsite statistics */
-  h_t *task_callsite_stats;
-
-  mpiPi_msg_stat_t coll, pt2pt;
-} mpiPi_thread_stat_t;
-
-int mpiPi_stats_thr_init(mpiPi_thread_stat_t *stat);
-void mpiPi_stats_thr_fini(mpiPi_thread_stat_t *stat);
-void mpiPi_stats_thr_cs_gather(mpiPi_thread_stat_t *stat,
+int mpiPi_stats_mt_init(mpiPi_mt_stat_t *stat);
+void mpiPi_stats_mt_fini(mpiPi_mt_stat_t *stat);
+void mpiPi_stats_mt_cs_gather(mpiPi_mt_stat_t *stat,
                              int *ac, callsite_stats_t ***av );
-void mpiPi_stats_thr_cs_upd (mpiPi_thread_stat_t *stat,
+void mpiPi_stats_mt_cs_upd (mpiPi_mt_stat_t *stat,
                            unsigned op, unsigned rank, void **pc,
                            double dur, double sendSize, double ioSize,
                            double rmaSize);
 #define MPIPI_CALLSITE_MIN2MAX 1
 #define MPIPI_CALLSITE_MIN2ZERO 0
-void mpiPi_stats_thr_cs_lookup(mpiPi_thread_stat_t *stat,
+void mpiPi_stats_mt_cs_lookup(mpiPi_mt_stat_t *stat,
                               callsite_stats_t *task_stats,
                               callsite_stats_t **task_lookup,
                               callsite_stats_t *dummy_buf,
                               int initMax);
 
-void mpiPi_stats_thr_coll_upd(mpiPi_thread_stat_t *stat,
+void mpiPi_stats_mt_coll_upd(mpiPi_mt_stat_t *stat,
                                   int op, double dur, double size,
                                   MPI_Comm * comm);
-void mpiPi_stats_thr_coll_gather(mpiPi_thread_stat_t *stat, double **_outbuf);
-void mpiPi_stats_thr_cs_reset(mpiPi_thread_stat_t *stat);
-void mpiPi_stats_thr_coll_binstrings(mpiPi_thread_stat_t *stat,
+void mpiPi_stats_mt_coll_gather(mpiPi_mt_stat_t *stat, double **_outbuf);
+void mpiPi_stats_mt_cs_reset(mpiPi_mt_stat_t *stat);
+void mpiPi_stats_mt_coll_binstrings(mpiPi_mt_stat_t *stat,
                                      int comm_idx, char *comm_buf,
                                      int size_idx, char *size_buf);
 
-void mpiPi_stats_thr_pt2pt_upd (mpiPi_thread_stat_t *stat,
+void mpiPi_stats_mt_pt2pt_upd (mpiPi_mt_stat_t *stat,
                                    int op, double dur, double size,
                                    MPI_Comm * comm);
-void mpiPi_stats_thr_pt2pt_gather(mpiPi_thread_stat_t *stat, double **_outbuf);
-void mpiPi_stats_thr_pt2pt_binstrings(mpiPi_thread_stat_t *stat,
+void mpiPi_stats_mt_pt2pt_gather(mpiPi_mt_stat_t *stat, double **_outbuf);
+void mpiPi_stats_mt_pt2pt_binstrings(mpiPi_mt_stat_t *stat,
                                      int comm_idx, char *comm_buf,
                                      int size_idx, char *size_buf);
 
-int mpiPi_stats_thr_exit(mpiPi_thread_stat_t *stat);
-int mpiPi_stats_thr_enter(mpiPi_thread_stat_t *stat);
-int mpiPi_stats_thr_is_on(mpiPi_thread_stat_t *stat);
+int mpiPi_stats_mt_exit(mpiPi_mt_stat_t *stat);
+int mpiPi_stats_mt_enter(mpiPi_mt_stat_t *stat);
+int mpiPi_stats_mt_is_on(mpiPi_mt_stat_t *stat);
 
-#endif
+#endif // MPIPMTSTATS_H
 
 /*
-  
+
   <license>
-  
-  Copyright (c) 2006, The Regents of the University of California. 
-  Produced at the Lawrence Livermore National Laboratory 
-  Written by Jeffery Vetter and Christopher Chambreau. 
-  UCRL-CODE-223450. 
-  All rights reserved. 
 
   Copyright (c) 2019, Mellanox Technologies Inc.
   Written by Artem Polyakov
   All rights reserved.
 
-   
-  This file is part of mpiP.  For details, see http://llnl.github.io/mpiP. 
-   
+
+  This file is part of mpiP.  For details, see http://llnl.github.io/mpiP.
+
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are
   met:
-   
+
   * Redistributions of source code must retain the above copyright
   notice, this list of conditions and the disclaimer below.
-  
+
   * Redistributions in binary form must reproduce the above copyright
   notice, this list of conditions and the disclaimer (as noted below) in
   the documentation and/or other materials provided with the
   distribution.
-  
+
   * Neither the name of the UC/LLNL nor the names of its contributors
   may be used to endorse or promote products derived from this software
   without specific prior written permission.
-  
+
   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -168,22 +88,22 @@ int mpiPi_stats_thr_is_on(mpiPi_thread_stat_t *stat);
   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-   
-   
-  Additional BSD Notice 
-   
+
+
+  Additional BSD Notice
+
   1. This notice is required to be provided under our contract with the
   U.S. Department of Energy (DOE).  This work was produced at the
   University of California, Lawrence Livermore National Laboratory under
   Contract No. W-7405-ENG-48 with the DOE.
-   
+
   2. Neither the United States Government nor the University of
   California nor any of their employees, makes any warranty, express or
   implied, or assumes any liability or responsibility for the accuracy,
   completeness, or usefulness of any information, apparatus, product, or
   process disclosed, or represents that its use would not infringe
   privately-owned rights.
-   
+
   3.  Also, reference herein to any specific commercial products,
   process, or services by trade name, trademark, manufacturer or
   otherwise does not necessarily constitute or imply its endorsement,
@@ -192,9 +112,7 @@ int mpiPi_stats_thr_is_on(mpiPi_thread_stat_t *stat);
   herein do not necessarily state or reflect those of the United States
   Government or the University of California, and shall not be used for
   advertising or product endorsement purposes.
-  
-  </license>
-  
-*/
 
-/* EOF */
+  </license>
+
+*/

--- a/mpiP-mt-stats.h
+++ b/mpiP-mt-stats.h
@@ -2,24 +2,38 @@
 #define MPIPMTSTATS_H
 
 #include "mpiP-stats.h"
+#include "mpiP-tslist.h"
+#include <pthread.h>
+
+typedef enum {
+  MPIPI_MODE_ST,
+  MPIPI_MODE_MT
+} mpiPi_thr_mode_t;
+
+typedef struct {
+  mpiPi_thread_stat_t merget_stat;
+
+} _mpiPi_mt_state_t;
 
 /* Per-thread MPI status */
 typedef struct {
-  union {
-    mpiPi_thread_stat_t st_stat;
-  };
+  mpiPi_thr_mode_t mode;
+  mpiPi_thread_stat_t rank_stats;
+  mpiP_tslist_t *tls_list;
+  pthread_key_t tls_this;
 } mpiPi_mt_stat_t;
 
-int mpiPi_stats_mt_init(mpiPi_mt_stat_t *stat);
+int mpiPi_stats_mt_init(mpiPi_mt_stat_t *stat, mpiPi_thr_mode_t mode);
 void mpiPi_stats_mt_fini(mpiPi_mt_stat_t *stat);
+void mpiPi_stats_mt_merge(mpiPi_mt_stat_t *mt_state);
+
 void mpiPi_stats_mt_cs_gather(mpiPi_mt_stat_t *stat,
                              int *ac, callsite_stats_t ***av );
 void mpiPi_stats_mt_cs_upd (mpiPi_mt_stat_t *stat,
                            unsigned op, unsigned rank, void **pc,
                            double dur, double sendSize, double ioSize,
                            double rmaSize);
-#define MPIPI_CALLSITE_MIN2MAX 1
-#define MPIPI_CALLSITE_MIN2ZERO 0
+
 void mpiPi_stats_mt_cs_lookup(mpiPi_mt_stat_t *stat,
                               callsite_stats_t *task_stats,
                               callsite_stats_t **task_lookup,

--- a/mpiP-mt-stats.h
+++ b/mpiP-mt-stats.h
@@ -14,6 +14,7 @@ typedef struct mpiPi_mt_stat_s mpiPi_mt_stat_t;
 
 typedef struct {
   mpiPi_mt_stat_t *mt_state;
+  int is_active;
   mpiPi_thread_stat_t *tls_ptr;
 } mpiPi_mt_stat_tls_t;
 

--- a/mpiP-mt-stats.h
+++ b/mpiP-mt-stats.h
@@ -33,6 +33,9 @@ int mpiPi_stats_mt_init(mpiPi_mt_stat_t *stat, mpiPi_thr_mode_t mode);
 void mpiPi_stats_mt_fini(mpiPi_mt_stat_t *stat);
 void mpiPi_stats_mt_merge(mpiPi_mt_stat_t *mt_state);
 
+void mpiPi_stats_mt_timer_stop(mpiPi_mt_stat_t *mt_state);
+void mpiPi_stats_mt_timer_start(mpiPi_mt_stat_t *mt_state);
+double mpiPi_stats_mt_cum_time(mpiPi_mt_stat_t *mt_state);
 mpiPi_mt_stat_tls_t *mpiPi_stats_mt_gettls(mpiPi_mt_stat_t *mt_state);
 
 void mpiPi_stats_mt_cs_gather(mpiPi_mt_stat_t *stat,

--- a/mpiP-stats.c
+++ b/mpiP-stats.c
@@ -160,6 +160,11 @@ mpiPi_stats_thr_cs_upd (mpiPi_thread_stat_t *stat,
 
   assert (dur >= 0);
 
+
+  /* Check for the nested calls */
+  if (!mpiPi_stats_thr_is_on(stat))
+    return;
+
   key.op = op;
   key.rank = rank;
   key.cookie = MPIP_CALLSITE_STATS_COOKIE;
@@ -346,6 +351,10 @@ void mpiPi_stats_thr_coll_upd (mpiPi_thread_stat_t *stat,
                                   int op, double dur, double size,
                                   MPI_Comm * comm)
 {
+  /* Check for the nested calls */
+  if (!mpiPi_stats_thr_is_on(stat))
+    return;
+
   _update_msize_stat(&stat->coll, op, dur, size, comm, "collectives");
 }
 
@@ -367,6 +376,10 @@ void mpiPi_stats_thr_pt2pt_upd (mpiPi_thread_stat_t *stat,
                                    int op, double dur, double size,
                                    MPI_Comm * comm)
 {
+  /* Check for the nested calls */
+  if (!mpiPi_stats_thr_is_on(stat))
+    return;
+
   _update_msize_stat(&stat->pt2pt, op, dur, size, comm, "point-to-point");
 }
 

--- a/mpiP-stats.c
+++ b/mpiP-stats.c
@@ -224,12 +224,11 @@ void mpiPi_stats_thr_cs_reset(mpiPi_thread_stat_t *stat)
   callsite_stats_t *csp = NULL;
 
   /* gather local task data */
-  mpiPi_stats_thr_cs_gather(stat, &ac, &av );
+  h_drain(stat->cs_stats, &ac, (void ***)&av);
 
   for (ndx = 0; ndx < ac; ndx++)
     {
-      csp = av[ndx];
-      mpiPi_cs_reset_stat(csp);
+      free(av[ndx]);
     }
   free(av);
 }

--- a/mpiP-stats.h
+++ b/mpiP-stats.h
@@ -50,13 +50,18 @@ typedef struct {
   int disabled;
 
   /* Callsite statistics */
-  h_t *task_callsite_stats;
+  h_t *cs_stats;
 
+  /* Collectives and point-to-point statistics */
   mpiPi_msg_stat_t coll, pt2pt;
 } mpiPi_thread_stat_t;
 
 int mpiPi_stats_thr_init(mpiPi_thread_stat_t *stat);
 void mpiPi_stats_thr_fini(mpiPi_thread_stat_t *stat);
+void mpiPi_stats_thr_reset_all(mpiPi_thread_stat_t *stat);
+void mpiPi_stats_thr_merge_all(mpiPi_thread_stat_t *dst,
+                               mpiPi_thread_stat_t *src);
+
 void mpiPi_stats_thr_cs_gather(mpiPi_thread_stat_t *stat,
                              int *ac, callsite_stats_t ***av );
 
@@ -71,12 +76,17 @@ void mpiPi_stats_thr_cs_lookup(mpiPi_thread_stat_t *stat,
                               callsite_stats_t **task_lookup,
                               callsite_stats_t *dummy_buf,
                               int initMax);
+void mpiPi_stats_thr_cs_merge(mpiPi_thread_stat_t *dst,
+                              mpiPi_thread_stat_t *src);
 
 void mpiPi_stats_thr_coll_upd(mpiPi_thread_stat_t *stat,
                                   int op, double dur, double size,
                                   MPI_Comm * comm);
 void mpiPi_stats_thr_coll_gather(mpiPi_thread_stat_t *stat, double **_outbuf);
 void mpiPi_stats_thr_cs_reset(mpiPi_thread_stat_t *stat);
+void mpiPi_stats_thr_coll_merge(mpiPi_thread_stat_t *dst,
+                                mpiPi_thread_stat_t *src);
+
 void mpiPi_stats_thr_coll_binstrings(mpiPi_thread_stat_t *stat,
                                      int comm_idx, char *comm_buf,
                                      int size_idx, char *size_buf);
@@ -85,6 +95,8 @@ void mpiPi_stats_thr_pt2pt_upd (mpiPi_thread_stat_t *stat,
                                    int op, double dur, double size,
                                    MPI_Comm * comm);
 void mpiPi_stats_thr_pt2pt_gather(mpiPi_thread_stat_t *stat, double **_outbuf);
+void mpiPi_stats_thr_pt2pt_merge(mpiPi_thread_stat_t *dst,
+                                mpiPi_thread_stat_t *src);
 void mpiPi_stats_thr_pt2pt_binstrings(mpiPi_thread_stat_t *stat,
                                      int comm_idx, char *comm_buf,
                                      int size_idx, char *size_buf);

--- a/mpiP-stats.h
+++ b/mpiP-stats.h
@@ -20,6 +20,7 @@
 #include "mpiPconfig.h"
 #include "mpiP-hash.h"
 #include "mpiPi_def.h"
+#include "mpiP-callsites.h"
 
 
 /* Histograms */
@@ -29,36 +30,6 @@ typedef struct _mpiPi_histogram
   int hist_size;
   int *bin_intervals;
 } mpiPi_histogram_t;
-
-/* Callsite statistics */
-typedef struct _callsite_stats
-{
-  unsigned op;
-  unsigned rank;
-  int csid;
-  long long count;
-  double cumulativeTime;
-  double cumulativeTimeSquared;
-  double maxDur;
-  double minDur;
-  double maxDataSent;
-  double minDataSent;
-  double maxIO;
-  double minIO;
-  double maxRMA;
-  double minRMA;
-  double cumulativeDataSent;
-  double cumulativeIO;
-  double cumulativeRMA;
-  long long arbitraryMessageCount;
-  double *siteData;
-  int siteDataIdx;
-  void *pc[MPIP_CALLSITE_STACK_DEPTH_MAX];
-  char *filename[MPIP_CALLSITE_STACK_DEPTH_MAX];
-  char *functname[MPIP_CALLSITE_STACK_DEPTH_MAX];
-  int lineno[MPIP_CALLSITE_STACK_DEPTH_MAX];
-  long cookie;
-} callsite_stats_t;
 
 /* Message/Communicator statistics */
 #define MPIP_NFUNC (mpiPi_DEF_END - mpiPi_BASE)
@@ -88,6 +59,7 @@ int mpiPi_stats_thr_init(mpiPi_thread_stat_t *stat);
 void mpiPi_stats_thr_fini(mpiPi_thread_stat_t *stat);
 void mpiPi_stats_thr_cs_gather(mpiPi_thread_stat_t *stat,
                              int *ac, callsite_stats_t ***av );
+
 void mpiPi_stats_thr_cs_upd (mpiPi_thread_stat_t *stat,
                            unsigned op, unsigned rank, void **pc,
                            double dur, double sendSize, double ioSize,

--- a/mpiP-stats.h
+++ b/mpiP-stats.h
@@ -21,7 +21,7 @@
 #include "mpiP-hash.h"
 #include "mpiPi_def.h"
 #include "mpiP-callsites.h"
-
+#include "mpip_timers.h"
 
 /* Histograms */
 typedef struct _mpiPi_histogram
@@ -49,9 +49,12 @@ typedef struct {
    */
   int disabled;
 
+  /* Usage time */
+  mpiPi_TIME ts_start, ts_end;
+  double cum_time;
+
   /* Callsite statistics */
   h_t *cs_stats;
-
   /* Collectives and point-to-point statistics */
   mpiPi_msg_stat_t coll, pt2pt;
 } mpiPi_thread_stat_t;
@@ -61,6 +64,10 @@ void mpiPi_stats_thr_fini(mpiPi_thread_stat_t *stat);
 void mpiPi_stats_thr_reset_all(mpiPi_thread_stat_t *stat);
 void mpiPi_stats_thr_merge_all(mpiPi_thread_stat_t *dst,
                                mpiPi_thread_stat_t *src);
+
+void mpiPi_stats_thr_timer_start(mpiPi_thread_stat_t *s);
+void mpiPi_stats_thr_timer_stop(mpiPi_thread_stat_t *s);
+double mpiPi_stats_thr_cum_time(mpiPi_thread_stat_t *s);
 
 void mpiPi_stats_thr_cs_gather(mpiPi_thread_stat_t *stat,
                              int *ac, callsite_stats_t ***av );

--- a/mpiP-threads.h
+++ b/mpiP-threads.h
@@ -1,0 +1,9 @@
+#ifndef MPIP_THREADS_H
+#define MPIP_THREADS_H
+
+#include "mpiPi_def.h"
+#include "mpiP-tslist.h"
+#include "mpiP-hash.h"
+#include "mpiP-statistics.h"
+
+#endif // MPIP_THREADS_H

--- a/mpiP-threads.h
+++ b/mpiP-threads.h
@@ -1,9 +1,0 @@
-#ifndef MPIP_THREADS_H
-#define MPIP_THREADS_H
-
-#include "mpiPi_def.h"
-#include "mpiP-tslist.h"
-#include "mpiP-hash.h"
-#include "mpiP-statistics.h"
-
-#endif // MPIP_THREADS_H

--- a/mpiP-tslist.c
+++ b/mpiP-tslist.c
@@ -35,9 +35,11 @@ void mpiPi_tslist_release(mpiP_tslist_t *list)
   free(list);
 }
 
-void mpiPi_tslist_append(mpiP_tslist_t *list, mpiP_tslist_elem_t *elem)
+void mpiPi_tslist_append(mpiP_tslist_t *list, void *data_ptr)
 {
+  mpiP_tslist_elem_t *elem = calloc(1, sizeof(*elem));
   elem->next = NULL;
+  elem->ptr = data_ptr;
   /* Ensure that all chnages to the elem structure are complete */////
   mpiP_atomic_wmb();
   /* Atomically swap the tail of the list to point to this element */

--- a/mpiP-tslist.c
+++ b/mpiP-tslist.c
@@ -1,0 +1,167 @@
+/* -*- C -*-
+
+   mpiP MPI Profiler ( http://llnl.github.io/mpiP )
+
+   Please see COPYRIGHT AND LICENSE information at the end of this file.
+
+   -----
+
+   thread_safe_list.c -- Implementation of the thread-safe list based on atomics
+   NOTE: only one thread is allowed to extract elements, but many can contribute.
+   This fits perfectly fine with the purpose of holding TLS pointers in mpiP.
+
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "arch/arch.h"
+#include "mpiP-tslist.h"
+
+mpiP_tslist_t *mpiPi_tslist_create()
+{
+  mpiP_tslist_t *list = calloc(1, sizeof(*list));
+  if( NULL == list ) {
+      return NULL;
+    }
+  list->head = calloc(1, sizeof(*list->head));
+  list->tail = list->head;
+  return list;
+}
+void mpiPi_tslist_release(mpiP_tslist_t *list)
+{
+  free(list->head);
+  list->head = list->tail = NULL;
+  free(list);
+}
+
+void mpiPi_tslist_append(mpiP_tslist_t *list, mpiP_tslist_elem_t *elem)
+{
+  elem->next = NULL;
+  /* Ensure that all chnages to the elem structure are complete */////
+  mpiP_atomic_wmb();
+  /* Atomically swap the tail of the list to point to this element */
+  mpiP_tslist_elem_t *prev = (mpiP_tslist_elem_t*)mpiP_atomic_swap((uint64_t*)&list->tail, (uint64_t)elem);
+  prev->next = elem;
+}
+
+void mpiPi_tslist_dequeue(mpiP_tslist_t *list, mpiP_tslist_elem_t **_elem)
+{
+  *_elem = NULL;
+  if( list->head == list->tail ){
+      // the list is empty
+      return;
+    }
+
+  if(list->head->next == NULL ){
+      // Someone is adding a new element, but it is not yet ready
+      return;
+    }
+
+  mpiP_tslist_elem_t *elem = list->head->next;
+  if( elem->next ) {
+      /* We have more than one elements in the list
+         * it is safe to dequeue this elemen as only one thread
+         * is allowed to dequeue
+         */
+      list->head->next = elem->next;
+      *_elem = elem;
+      /* Terminate element */
+      elem->next = NULL;
+      return;
+    }
+
+  mpiP_tslist_elem_t *iter;
+  /* requeue the dummy element to make sure that no one is adding currently */
+  mpiPi_tslist_append(list, list->head);
+  iter = elem;
+  while(iter->next != list->head) {
+      mpiP_atomic_isync();
+      if((volatile void*)iter->next) {
+          iter = iter->next;
+        }
+    }
+  /* Terminate the extracted chain */
+  iter->next = NULL;
+  *_elem = elem;
+}
+
+mpiP_tslist_elem_t *mpiPi_tslist_first(mpiP_tslist_t *list)
+{
+  return list->head->next;
+}
+
+mpiP_tslist_elem_t *mpiPi_tslist_next(mpiP_tslist_elem_t *current)
+{
+  return current->next;
+}
+
+/*
+
+<license>
+
+Derived from
+https://github.com/artpol84/poc/blob/master/arch/concurrency/thread-safe_list
+
+Copyright (c) 2019      Mellanox Technologies Ltd.
+Written by Artem Polyakov
+All rights reserved.
+
+This file is part of mpiP.  For details, see http://llnl.github.io/mpiP.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the disclaimer below.
+
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the disclaimer (as noted below) in
+the documentation and/or other materials provided with the
+distribution.
+
+* Neither the name of the UC/LLNL nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OF
+THE UNIVERSITY OF CALIFORNIA, THE U.S. DEPARTMENT OF ENERGY OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Additional BSD Notice
+
+1. This notice is required to be provided under our contract with the
+U.S. Department of Energy (DOE).  This work was produced at the
+University of California, Lawrence Livermore National Laboratory under
+Contract No. W-7405-ENG-48 with the DOE.
+
+2. Neither the United States Government nor the University of
+California nor any of their employees, makes any warranty, express or
+implied, or assumes any liability or responsibility for the accuracy,
+completeness, or usefulness of any information, apparatus, product, or
+process disclosed, or represents that its use would not infringe
+privately-owned rights.
+
+3.  Also, reference herein to any specific commercial products,
+process, or services by trade name, trademark, manufacturer or
+otherwise does not necessarily constitute or imply its endorsement,
+recommendation, or favoring by the United States Government or the
+University of California.  The views and opinions of authors expressed
+herein do not necessarily state or reflect those of the United States
+Government or the University of California, and shall not be used for
+advertising or product endorsement purposes.
+
+</license>
+
+*/

--- a/mpiP-tslist.c
+++ b/mpiP-tslist.c
@@ -43,7 +43,7 @@ void mpiPi_tslist_append(mpiP_tslist_t *list, void *data_ptr)
   /* Ensure that all chnages to the elem structure are complete */////
   mpiP_atomic_wmb();
   /* Atomically swap the tail of the list to point to this element */
-  mpiP_tslist_elem_t *prev = (mpiP_tslist_elem_t*)mpiP_atomic_swap((uint64_t*)&list->tail, (uint64_t)elem);
+  mpiP_tslist_elem_t *prev = (mpiP_tslist_elem_t*)mpiP_atomic_swap((void**)&list->tail, elem);
   prev->next = elem;
 }
 
@@ -80,7 +80,7 @@ void *mpiPi_tslist_dequeue(mpiP_tslist_t *list)
    */
   list->head->next = NULL;
   tmp = elem;
-  if( mpiP_atomic_cas((uint64_t*)&list->tail, (uint64_t*)&tmp, (uint64_t)list->head) ){
+  if( mpiP_atomic_cas((void**)&list->tail, (void**)&tmp, list->head) ){
       /* Replacement was successful, this means that list->head was placed
        * as the very first element of the list
        */

--- a/mpiP-tslist.h
+++ b/mpiP-tslist.h
@@ -29,7 +29,7 @@ typedef struct tslist_s {
 mpiP_tslist_t *mpiPi_tslist_create();
 void mpiPi_tslist_release(mpiP_tslist_t *list);
 void mpiPi_tslist_append(mpiP_tslist_t *list, void *data_ptr);
-void mpiPi_tslist_dequeue(mpiP_tslist_t *list, mpiP_tslist_elem_t **_elem);
+void *mpiPi_tslist_dequeue(mpiP_tslist_t *list);
 mpiP_tslist_elem_t *mpiPi_tslist_first(mpiP_tslist_t *list);
 mpiP_tslist_elem_t *mpiPi_tslist_next(mpiP_tslist_elem_t *current);
 

--- a/mpiP-tslist.h
+++ b/mpiP-tslist.h
@@ -28,7 +28,7 @@ typedef struct tslist_s {
 
 mpiP_tslist_t *mpiPi_tslist_create();
 void mpiPi_tslist_release(mpiP_tslist_t *list);
-void mpiPi_tslist_append(mpiP_tslist_t *list, mpiP_tslist_elem_t *ptr);
+void mpiPi_tslist_append(mpiP_tslist_t *list, void *data_ptr);
 void mpiPi_tslist_dequeue(mpiP_tslist_t *list, mpiP_tslist_elem_t **_elem);
 mpiP_tslist_elem_t *mpiPi_tslist_first(mpiP_tslist_t *list);
 mpiP_tslist_elem_t *mpiPi_tslist_next(mpiP_tslist_elem_t *current);

--- a/mpiP-tslist.h
+++ b/mpiP-tslist.h
@@ -1,0 +1,106 @@
+/* -*- C -*-
+
+   mpiP MPI Profiler ( http://llnl.github.io/mpiP )
+
+   Please see COPYRIGHT AND LICENSE information at the end of this file.
+
+   -----
+
+   thread_safe_list.h -- Implementation of the thread-safe list based on atomics
+   NOTE: only one thread is allowed to extract elements, but many can contribute.
+   This fits perfectly fine with the purpose of holding TLS pointers in mpiP.
+
+ */
+
+#ifndef THREAD_SAFE_LIST_H
+#define THREAD_SAFE_LIST_H
+
+#include "arch/arch.h"
+
+typedef struct tslist_elem_s {
+  void *ptr;
+  struct tslist_elem_s *next;
+} mpiP_tslist_elem_t;
+
+typedef struct tslist_s {
+  mpiP_tslist_elem_t *head, *tail;
+} mpiP_tslist_t;
+
+mpiP_tslist_t *mpiPi_tslist_create();
+void mpiPi_tslist_release(mpiP_tslist_t *list);
+void mpiPi_tslist_append(mpiP_tslist_t *list, mpiP_tslist_elem_t *ptr);
+void mpiPi_tslist_dequeue(mpiP_tslist_t *list, mpiP_tslist_elem_t **_elem);
+mpiP_tslist_elem_t *mpiPi_tslist_first(mpiP_tslist_t *list);
+mpiP_tslist_elem_t *mpiPi_tslist_next(mpiP_tslist_elem_t *current);
+
+#endif // THREAD_SAFE_LIST_H
+
+/*
+
+<license>
+
+Derived from
+https://github.com/artpol84/poc/blob/master/arch/concurrency/thread-safe_list
+
+Copyright (c) 2019      Mellanox Technologies Ltd.
+Written by Artem Polyakov
+All rights reserved.
+
+This file is part of mpiP.  For details, see http://llnl.github.io/mpiP.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the disclaimer below.
+
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the disclaimer (as noted below) in
+the documentation and/or other materials provided with the
+distribution.
+
+* Neither the name of the UC/LLNL nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OF
+THE UNIVERSITY OF CALIFORNIA, THE U.S. DEPARTMENT OF ENERGY OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Additional BSD Notice
+
+1. This notice is required to be provided under our contract with the
+U.S. Department of Energy (DOE).  This work was produced at the
+University of California, Lawrence Livermore National Laboratory under
+Contract No. W-7405-ENG-48 with the DOE.
+
+2. Neither the United States Government nor the University of
+California nor any of their employees, makes any warranty, express or
+implied, or assumes any liability or responsibility for the accuracy,
+completeness, or usefulness of any information, apparatus, product, or
+process disclosed, or represents that its use would not infringe
+privately-owned rights.
+
+3.  Also, reference herein to any specific commercial products,
+process, or services by trade name, trademark, manufacturer or
+otherwise does not necessarily constitute or imply its endorsement,
+recommendation, or favoring by the United States Government or the
+University of California.  The views and opinions of authors expressed
+herein do not necessarily state or reflect those of the United States
+Government or the University of California, and shall not be used for
+advertising or product endorsement purposes.
+
+</license>
+
+*/

--- a/mpiPconfig.h.in
+++ b/mpiPconfig.h.in
@@ -99,6 +99,9 @@
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 
+/* The size of `void*', as computed by sizeof. */
+#undef SIZEOF_VOIDP
+
 /* SO lookup */
 #undef SO_LOOKUP
 

--- a/mpiPi.c
+++ b/mpiPi.c
@@ -1085,9 +1085,6 @@ mpiPi_update_callsite_stats (unsigned op, unsigned rank, void **pc,
   callsite_stats_t *csp = NULL;
   callsite_stats_t key;
 
-  if (!mpiPi_stats_mt_is_on(&mpiPi.task_stats))
-    return;
-
   mpiPi_stats_mt_cs_upd(&mpiPi.task_stats, op, rank, pc, dur,
                          sendSize, ioSize, rmaSize);
 }

--- a/mpiPi.c
+++ b/mpiPi.c
@@ -48,14 +48,6 @@ mpiPi_callsite_stats_src_comparator (const void *p1, const void *p2)
 }
 
 static int
-mpiPi_callsite_stats_MPI_id_hashkey (const void *p)
-{
-  callsite_stats_t *csp = (callsite_stats_t *) p;
-  MPIP_CALLSITE_STATS_COOKIE_ASSERT (csp);
-  return 52271 ^ csp->op;
-}
-
-static int
 mpiPi_callsite_stats_src_id_hashkey (const void *p)
 {
   int res = 0;
@@ -184,264 +176,6 @@ mpiPi_init (char *appName)
 #endif /* } ifndef ENABLE_API_ONLY */
 
 
-typedef struct callsite_cache_entry_t
-{
-  void *pc;
-  char *filename;
-  char *functname;
-  int line;
-}
-callsite_pc_cache_entry_t;
-
-h_t *callsite_pc_cache = NULL;
-
-static int
-callsite_pc_cache_comparator (const void *p1, const void *p2)
-{
-  callsite_pc_cache_entry_t *cs1 = (callsite_pc_cache_entry_t *) p1;
-  callsite_pc_cache_entry_t *cs2 = (callsite_pc_cache_entry_t *) p2;
-
-  if ((long) cs1->pc > (long) cs2->pc)
-    {
-      return 1;
-    }
-  if ((long) cs1->pc < (long) cs2->pc)
-    {
-      return -1;
-    }
-  return 0;
-}
-
-static int
-callsite_pc_cache_hashkey (const void *p1)
-{
-  callsite_pc_cache_entry_t *cs1 = (callsite_pc_cache_entry_t *) p1;
-  return 662917 ^ ((long) cs1->pc);
-}
-
-int
-mpiPi_query_pc (void *pc, char **filename, char **functname, int *lineno)
-{
-  int rc = 0;
-  callsite_pc_cache_entry_t key;
-  callsite_pc_cache_entry_t *csp;
-  char addr_buf[24];
-
-  key.pc = pc;
-  /* do we have a cache entry for this pc? If so, use entry */
-  if (h_search (callsite_pc_cache, &key, (void **) &csp) == NULL)
-    {
-      /* no cache entry: create, lookup, and insert */
-      csp =
-          (callsite_pc_cache_entry_t *)
-          malloc (sizeof (callsite_pc_cache_entry_t));
-      csp->pc = pc;
-#if defined(ENABLE_BFD) || defined(USE_LIBDWARF)
-      if (mpiP_find_src_loc (pc, filename, lineno, functname) == 0)
-        {
-          if (*filename == NULL || strcmp (*filename, "??") == 0)
-            *filename = "[unknown]";
-
-          if (*functname == NULL)
-            *functname = "[unknown]";
-
-          mpiPi_msg_debug
-              ("Successful Source lookup for [%s]: %s, %d, %s\n",
-               mpiP_format_address (pc, addr_buf), *filename, *lineno,
-               *functname);
-
-          csp->filename = strdup (*filename);
-          csp->functname = strdup (*functname);
-          csp->line = *lineno;
-        }
-      else
-        {
-          mpiPi_msg_debug ("Unsuccessful Source lookup for [%s]\n",
-                           mpiP_format_address (pc, addr_buf));
-          csp->filename = strdup ("[unknown]");
-          csp->functname = strdup ("[unknown]");
-          csp->line = 0;
-        }
-#else /* ! ENABLE_BFD || USE_LIBDWARF */
-      csp->filename = strdup ("[unknown]");
-      csp->functname = strdup ("[unknown]");
-      csp->line = 0;
-#endif
-      h_insert (callsite_pc_cache, csp);
-    }
-
-  *filename = csp->filename;
-  *functname = csp->functname;
-  *lineno = csp->line;
-
-  if (*lineno == 0)
-    rc = 1;			/* use this value to indicate a failed lookup */
-
-  return rc;
-}
-
-
-h_t *callsite_src_id_cache = NULL;
-int callsite_src_id_counter = 1;
-
-static int
-callsite_src_id_cache_comparator (const void *p1, const void *p2)
-{
-  int i;
-  callsite_src_id_cache_entry_t *csp_1 = (callsite_src_id_cache_entry_t *) p1;
-  callsite_src_id_cache_entry_t *csp_2 = (callsite_src_id_cache_entry_t *) p2;
-
-#define express(f) {if ((csp_1->f) > (csp_2->f)) {return 1;} if ((csp_1->f) < (csp_2->f)) {return -1;}}
-  if (mpiPi.stackDepth == 0)
-    {
-      express (id);		/* In cases where the call stack depth is 0, the only unique info may be the id */
-      return 0;
-    }
-  else
-    {
-      for (i = 0; i < MPIP_CALLSITE_STACK_DEPTH; i++)
-        {
-          if (csp_1->filename[i] != NULL && csp_2->filename[i] != NULL)
-            {
-              if (strcmp (csp_1->filename[i], csp_2->filename[i]) > 0)
-                {
-                  return 1;
-                }
-              if (strcmp (csp_1->filename[i], csp_2->filename[i]) < 0)
-                {
-                  return -1;
-                }
-              express (line[i]);
-              if (strcmp (csp_1->functname[i], csp_2->functname[i]) > 0)
-                {
-                  return 1;
-                }
-              if (strcmp (csp_1->functname[i], csp_2->functname[i]) < 0)
-                {
-                  return -1;
-                }
-            }
-
-          express (pc[i]);
-        }
-    }
-#undef express
-  return 0;
-}
-
-static int
-callsite_src_id_cache_hashkey (const void *p1)
-{
-  int i, j;
-  int res = 0;
-  callsite_src_id_cache_entry_t *cs1 = (callsite_src_id_cache_entry_t *) p1;
-  for (i = 0; i < MPIP_CALLSITE_STACK_DEPTH; i++)
-    {
-      if (cs1->filename[i] != NULL)
-        {
-          for (j = 0; cs1->filename[i][j] != '\0'; j++)
-            {
-              res ^= (unsigned) cs1->filename[i][j];
-            }
-          for (j = 0; cs1->functname[i][j] != '\0'; j++)
-            {
-              res ^= (unsigned) cs1->functname[i][j];
-            }
-        }
-      res ^= cs1->line[i];
-    }
-  return 662917 ^ res;
-}
-
-/* take a callstats record (the pc) and determine src file, line, if
-   possible and assign a callsite id.
- */
-int
-mpiPi_query_src (callsite_stats_t * p)
-{
-  int i;
-  callsite_src_id_cache_entry_t key;
-  callsite_src_id_cache_entry_t *csp;
-  assert (p);
-
-  /* Because multiple pcs can map to the same source line, we must
-     check that mapping here. If we got unknown, then we assign
-     different ids */
-  bzero (&key, sizeof (callsite_src_id_cache_entry_t));
-
-  for (i = 0; (i < MPIP_CALLSITE_STACK_DEPTH) && (p->pc[i] != NULL); i++)
-    {
-      if (mpiPi.do_lookup == 1)
-        mpiPi_query_pc (p->pc[i], &(p->filename[i]), &(p->functname[i]),
-                        &(p->lineno[i]));
-      else
-        {
-          p->filename[i] = strdup ("[unknown]");
-          p->functname[i] = strdup ("[unknown]");
-          p->lineno[i] = 0;
-        }
-
-      key.filename[i] = p->filename[i];
-      key.functname[i] = p->functname[i];
-      key.line[i] = p->lineno[i];
-      key.pc[i] = p->pc[i];
-    }
-
-  /* MPI ID is compared when stack depth is 0 */
-  key.id = p->op - mpiPi_BASE;
-
-  /* lookup/generate an ID based on the callstack, not just the callsite pc */
-  if (h_search (callsite_src_id_cache, &key, (void **) &csp) == NULL)
-    {
-      /* create a new entry, and assign an id based on callstack */
-      csp =
-          (callsite_src_id_cache_entry_t *)
-          malloc (sizeof (callsite_src_id_cache_entry_t));
-      bzero (csp, sizeof (callsite_src_id_cache_entry_t));
-
-      for (i = 0; (i < MPIP_CALLSITE_STACK_DEPTH) && (p->pc[i] != NULL); i++)
-        {
-          csp->filename[i] = strdup (key.filename[i]);
-          csp->functname[i] = strdup (key.functname[i]);
-          csp->line[i] = key.line[i];
-          csp->pc[i] = p->pc[i];
-        }
-      csp->op = p->op;
-      if (mpiPi.stackDepth == 0)
-        csp->id = csp->op - mpiPi_BASE;
-      else
-        csp->id = callsite_src_id_counter++;
-      h_insert (callsite_src_id_cache, csp);
-    }
-
-  /* assign ID to this record */
-  p->csid = csp->id;
-
-  return p->csid;
-}
-
-
-static void
-mpiPi_merge_individual_callsite_records (callsite_stats_t * a,
-                                         callsite_stats_t * b)
-{
-  a->count += b->count;
-  a->cumulativeTime += b->cumulativeTime;
-  assert (a->cumulativeTime >= 0);
-  a->cumulativeTimeSquared += b->cumulativeTimeSquared;
-  assert (a->cumulativeTimeSquared >= 0);
-  a->maxDur = max (a->maxDur, b->maxDur);
-  a->minDur = min (a->minDur, b->minDur);
-  a->maxDataSent = max (a->maxDataSent, b->maxDataSent);
-  a->minDataSent = min (a->minDataSent, b->minDataSent);
-  a->cumulativeDataSent += b->cumulativeDataSent;
-  a->maxIO = max (a->maxIO, b->maxIO);
-  a->minIO = min (a->minIO, b->minIO);
-  a->cumulativeIO += b->cumulativeIO;
-  a->cumulativeRMA += b->cumulativeRMA;
-  a->arbitraryMessageCount += b->arbitraryMessageCount;
-}
-
 
 static int
 mpiPi_insert_callsite_records (callsite_stats_t * p)
@@ -469,7 +203,7 @@ mpiPi_insert_callsite_records (callsite_stats_t * p)
           h_insert (mpiPi.global_callsite_stats, newp);
         }
       else
-        mpiPi_merge_individual_callsite_records (csp, p);
+        mpiPi_cs_merge(csp, p);
     }
 
   /* Collect aggregate callsite summary information indpendent of rank. */
@@ -493,7 +227,7 @@ mpiPi_insert_callsite_records (callsite_stats_t * p)
     }
   else
     {
-      mpiPi_merge_individual_callsite_records (csp, p);
+      mpiPi_cs_merge(csp, p);
 
       if (mpiPi.calcCOV)
         {
@@ -538,6 +272,15 @@ callsite_sort_by_MPI_op (const void *a, const void *b)
       return -1;
     }
   return 0;
+}
+
+
+static int
+mpiPi_callsite_stats_MPI_id_hashkey (const void *p)
+{
+  callsite_stats_t *csp = (callsite_stats_t *) p;
+  MPIP_CALLSITE_STATS_COOKIE_ASSERT (csp);
+  return 52271 ^ csp->op;
 }
 
 static int
@@ -598,7 +341,7 @@ mpiPi_insert_MPI_records ()
             }
           else
             {
-              mpiPi_merge_individual_callsite_records (csp, p);
+              mpiPi_cs_merge(csp, p);
             }
         }
     }
@@ -683,18 +426,7 @@ mpiPi_mergeResults ()
       mpiPi.global_callsite_stats_agg = h_open (mpiPi.tableSize,
                                                 mpiPi_callsite_stats_src_id_hashkey,
                                                 mpiPi_callsite_stats_src_id_comparator);
-      if (callsite_pc_cache == NULL)
-        {
-          callsite_pc_cache = h_open (mpiPi.tableSize,
-                                      callsite_pc_cache_hashkey,
-                                      callsite_pc_cache_comparator);
-        }
-      if (callsite_src_id_cache == NULL)
-        {
-          callsite_src_id_cache = h_open (mpiPi.tableSize,
-                                          callsite_src_id_cache_hashkey,
-                                          callsite_src_id_cache_comparator);
-        }
+      mpiPi_cs_cache_init();
 
       /* Clear global_mpi_time and global_mpi_size before accumulation in mpiPi_insert_callsite_records */
       mpiPi.global_mpi_time = 0.0;

--- a/mpiPi.c
+++ b/mpiPi.c
@@ -157,7 +157,7 @@ mpiPi_init (char *appName)
 #endif
   mpiPi_getenv ();
 
-  mpiPi_stats_thr_init(&mpiPi.task_stats);
+  mpiPi_stats_mt_init(&mpiPi.task_stats);
 
   /* -- welcome msg only collector  */
   if (mpiPi.collectorRank == mpiPi.rank)
@@ -619,7 +619,7 @@ mpiPi_mergeResults ()
   callsite_stats_t *rawCallsiteData = NULL;
 
   /* gather local task data */
-  mpiPi_stats_thr_cs_gather(&mpiPi.task_stats, &ac, &av);
+  mpiPi_stats_mt_cs_gather(&mpiPi.task_stats, &ac, &av);
 
   /* determine size of space necessary on collector */
   PMPI_Allreduce (&ac, &totalCount, 1, MPI_INT, MPI_SUM, mpiPi.comm);
@@ -793,7 +793,7 @@ mpiPi_mergeCollectiveStats ()
       coll_time_results = (double *) malloc (sizeof(mpiPi.coll_time_stats));
     }
 
-  mpiPi_stats_thr_coll_gather(&mpiPi.task_stats, &coll_time_local);
+  mpiPi_stats_mt_coll_gather(&mpiPi.task_stats, &coll_time_local);
 
   /*  Collect Collective statistic data were used  */
   size = sizeof(mpiPi.pt2pt_send_stats) / sizeof(double);
@@ -828,7 +828,7 @@ mpiPi_mergept2ptStats ()
   if (mpiPi.collectorRank == mpiPi.rank){
       pt2pt_send_results = (double *) malloc (sizeof(mpiPi.pt2pt_send_stats));
     }
-  mpiPi_stats_thr_pt2pt_gather(&mpiPi.task_stats, &pt2pt_send_local);
+  mpiPi_stats_mt_pt2pt_gather(&mpiPi.task_stats, &pt2pt_send_local);
 
   /*  Collect Collective statistic data were used  */
   size = sizeof(mpiPi.pt2pt_send_stats) / sizeof(double);
@@ -1050,7 +1050,7 @@ mpiPi_finalize ()
   if (mpiPi.disable_finalize_report == 0)
     mpiPi_generateReport (mpiPi.report_style);
 
-  mpiPi_stats_thr_fini(&mpiPi.task_stats);
+  mpiPi_stats_mt_fini(&mpiPi.task_stats);
 
   if (mpiPi.global_task_app_time != NULL)
     free (mpiPi.global_task_app_time);
@@ -1085,10 +1085,10 @@ mpiPi_update_callsite_stats (unsigned op, unsigned rank, void **pc,
   callsite_stats_t *csp = NULL;
   callsite_stats_t key;
 
-  if (!mpiPi_stats_thr_is_on(&mpiPi.task_stats))
+  if (!mpiPi_stats_mt_is_on(&mpiPi.task_stats))
     return;
 
-  mpiPi_stats_thr_cs_upd(&mpiPi.task_stats, op, rank, pc, dur,
+  mpiPi_stats_mt_cs_upd(&mpiPi.task_stats, op, rank, pc, dur,
                          sendSize, ioSize, rmaSize);
 }
 
@@ -1096,13 +1096,13 @@ void
 mpiPi_update_collective_stats (int op, double dur, double size,
                                MPI_Comm * comm)
 {
-  mpiPi_stats_thr_coll_upd(&mpiPi.task_stats, op, dur, size, comm);
+  mpiPi_stats_mt_coll_upd(&mpiPi.task_stats, op, dur, size, comm);
 }
 
 void
 mpiPi_update_pt2pt_stats (int op, double dur, double size, MPI_Comm * comm)
 {
-  mpiPi_stats_thr_pt2pt_upd(&mpiPi.task_stats, op, dur, size, comm);
+  mpiPi_stats_mt_pt2pt_upd(&mpiPi.task_stats, op, dur, size, comm);
 }
 
 #endif /* } ifndef ENABLE_API_ONLY */

--- a/mpiPi.c
+++ b/mpiPi.c
@@ -808,7 +808,8 @@ mpiPi_finalize ()
 
 
 void
-mpiPi_update_callsite_stats (unsigned op, unsigned rank, void **pc,
+mpiPi_update_callsite_stats (mpiPi_mt_stat_tls_t *tls,
+                             unsigned op, unsigned rank, void **pc,
                              double dur, double sendSize, double ioSize,
                              double rmaSize)
 {
@@ -816,21 +817,23 @@ mpiPi_update_callsite_stats (unsigned op, unsigned rank, void **pc,
   callsite_stats_t *csp = NULL;
   callsite_stats_t key;
 
-  mpiPi_stats_mt_cs_upd(&mpiPi.task_stats, op, rank, pc, dur,
-                         sendSize, ioSize, rmaSize);
+  mpiPi_stats_mt_cs_upd(tls, op, rank, pc, dur,
+                        sendSize, ioSize, rmaSize);
 }
 
 void
-mpiPi_update_collective_stats (int op, double dur, double size,
+mpiPi_update_collective_stats (mpiPi_mt_stat_tls_t *tls, int op, double dur, double size,
                                MPI_Comm * comm)
 {
-  mpiPi_stats_mt_coll_upd(&mpiPi.task_stats, op, dur, size, comm);
+  mpiPi_stats_mt_coll_upd(tls, op, dur, size, comm);
 }
 
 void
-mpiPi_update_pt2pt_stats (int op, double dur, double size, MPI_Comm * comm)
+mpiPi_update_pt2pt_stats (mpiPi_mt_stat_tls_t *tls,
+                          int op, double dur, double size,
+                          MPI_Comm * comm)
 {
-  mpiPi_stats_mt_pt2pt_upd(&mpiPi.task_stats, op, dur, size, comm);
+  mpiPi_stats_mt_pt2pt_upd(tls, op, dur, size, comm);
 }
 
 #endif /* } ifndef ENABLE_API_ONLY */

--- a/mpiPi.c
+++ b/mpiPi.c
@@ -78,7 +78,7 @@ mpiPi_callsite_stats_src_id_comparator (const void *p1, const void *p2)
 */
 
 void
-mpiPi_init (char *appName)
+mpiPi_init (char *appName, mpiPi_thr_mode_t thr_mode)
 {
   if (time (&mpiPi.start_timeofday) == (time_t) - 1)
     {
@@ -149,7 +149,7 @@ mpiPi_init (char *appName)
 #endif
   mpiPi_getenv ();
 
-  mpiPi_stats_mt_init(&mpiPi.task_stats);
+  mpiPi_stats_mt_init(&mpiPi.task_stats, thr_mode);
 
   /* -- welcome msg only collector  */
   if (mpiPi.collectorRank == mpiPi.rank)
@@ -174,8 +174,6 @@ mpiPi_init (char *appName)
   return;
 }
 #endif /* } ifndef ENABLE_API_ONLY */
-
-
 
 static int
 mpiPi_insert_callsite_records (callsite_stats_t * p)
@@ -746,6 +744,7 @@ mpiPi_generateReport (int report_style)
   mpiPi_msg_debug0 ("starting mergeResults\n");
 
   mpiPi_GETTIME (&timer_start);
+  mpiPi_stats_mt_merge(&mpiPi.task_stats);
   mergeResult = mpiPi_mergeResults ();
   if (mergeResult == 1 && mpiPi.stackDepth == 0)
     mergeResult = mpiPi_insert_MPI_records ();

--- a/mpiPi.h
+++ b/mpiPi.h
@@ -38,6 +38,7 @@
 #endif
 
 #include "mpiP-hash.h"
+#include "mpiP-callsites.h"
 #include "mpiP-mt-stats.h"
 
 #include "mpip_timers.h"

--- a/mpiPi.h
+++ b/mpiPi.h
@@ -38,7 +38,7 @@
 #endif
 
 #include "mpiP-hash.h"
-#include "mpiP-stats.h"
+#include "mpiP-mt-stats.h"
 
 #include "mpip_timers.h"
 
@@ -171,7 +171,7 @@ typedef struct _mpiPi_t
   h_t *global_callsite_stats_agg;
   h_t *global_MPI_stats_agg;
 
-  mpiPi_thread_stat_t task_stats;
+  mpiPi_mt_stat_t task_stats;
 
   mpiPi_lookup_t *lookup;
 

--- a/mpiPi.h
+++ b/mpiPi.h
@@ -143,8 +143,6 @@ typedef struct _mpiPi_t
   char *envStr;
   FILE *stdout_;
   FILE *stderr_;
-  mpiPi_TIME startTime;
-  mpiPi_TIME endTime;
 
   double cumulativeTime;	/* necessary for pcontrol */
   time_t start_timeofday;

--- a/mpiPi_proto.h
+++ b/mpiPi_proto.h
@@ -35,9 +35,6 @@ extern void *h_search (h_t * ht, void *key, void **ptr);
 extern void *h_delete (h_t * ht, void *key, void **ptr);
 extern int h_gather_data (h_t * ht, int *ac, void ***ptr);
 extern void mpiPi_init (char *appName);
-extern int mpiPi_query_pc (void *pc, char **filename, char **functname,
-                           int *lineno);
-extern int mpiPi_query_src (callsite_stats_t * p);
 extern void mpiPi_generateReport (int report_style);
 extern void mpiPi_finalize (void);
 extern void mpiPi_update_callsite_stats (unsigned op, unsigned rank,

--- a/mpiPi_proto.h
+++ b/mpiPi_proto.h
@@ -11,6 +11,7 @@
      $Id$
 
 */
+#include "mpiP-mt-stats.h"
 
 extern int open_dwarf_executable (char *fileName);
 extern void close_dwarf_executable (void);
@@ -37,7 +38,8 @@ extern int h_gather_data (h_t * ht, int *ac, void ***ptr);
 extern void mpiPi_init (char *appName, mpiPi_thr_mode_t thr_mode);
 extern void mpiPi_generateReport (int report_style);
 extern void mpiPi_finalize (void);
-extern void mpiPi_update_callsite_stats (unsigned op, unsigned rank,
+extern void mpiPi_update_callsite_stats (mpiPi_mt_stat_tls_t *hndl,
+                                         unsigned op, unsigned rank,
                                          void **pc, double dur,
                                          double sendSize, double ioSize,
                                          double rmaSize);
@@ -62,9 +64,9 @@ extern void mpiPi_copy_args (int *ac, char **av, int av_len);
 extern void mpiPi_copy_given_args (int *ac, char **av, int av_len, int argc,
                                    char **argv);
 extern unsigned long long mpiPi_get_text_start (char *filename);
-extern void mpiPi_update_collective_stats (int op, double dur, double size,
+extern void mpiPi_update_collective_stats (mpiPi_mt_stat_tls_t *tls, int op, double dur, double size,
                                            MPI_Comm * comm);
-extern void mpiPi_update_pt2pt_stats (int op, double dur, double size,
+extern void mpiPi_update_pt2pt_stats (mpiPi_mt_stat_tls_t *tls, int op, double dur, double size,
                                       MPI_Comm * comm);
 
 #ifdef NEED_MREAD_REAL_TIME_DECL

--- a/mpiPi_proto.h
+++ b/mpiPi_proto.h
@@ -34,7 +34,7 @@ extern int h_insert (h_t * ht, void *ptr);
 extern void *h_search (h_t * ht, void *key, void **ptr);
 extern void *h_delete (h_t * ht, void *key, void **ptr);
 extern int h_gather_data (h_t * ht, int *ac, void ***ptr);
-extern void mpiPi_init (char *appName);
+extern void mpiPi_init (char *appName, mpiPi_thr_mode_t thr_mode);
 extern void mpiPi_generateReport (int report_style);
 extern void mpiPi_finalize (void);
 extern void mpiPi_update_callsite_stats (unsigned op, unsigned rank,

--- a/pcontrol.c
+++ b/pcontrol.c
@@ -24,7 +24,7 @@ static char *svnid = "$Id$";
 void
 mpiPi_reset_callsite_data ()
 {
-  mpiPi_stats_thr_cs_reset(&mpiPi.task_stats);
+  mpiPi_stats_mt_cs_reset(&mpiPi.task_stats);
 
   if (time (&mpiPi.start_timeofday) == (time_t) - 1)
     {

--- a/pcontrol.c
+++ b/pcontrol.c
@@ -45,7 +45,7 @@ mpiPi_reset_callsite_data ()
       mpiPi_msg_warn ("Could not get time of day from time()\n");
     }
 
-  mpiPi_GETTIME (&mpiPi.startTime);
+  mpiPi_stats_mt_timer_start(&mpiPi.task_stats);
   mpiPi.cumulativeTime = 0;
 
   mpiPi.global_app_time = 0;
@@ -71,11 +71,7 @@ mpiPi_MPI_Pcontrol (const int flag)
         mpiPi_msg_warn
             ("MPI_Pcontrol trying to disable MPIP while it is already disabled.\n");
 
-      mpiPi_GETTIME (&mpiPi.endTime);
-      dur =
-          (mpiPi_GETTIMEDIFF (&mpiPi.endTime, &mpiPi.startTime) / 1000000.0);
-      mpiPi.cumulativeTime += dur;
-      assert (mpiPi.cumulativeTime >= 0);
+      mpiPi_stats_mt_timer_stop(&mpiPi.task_stats);
       mpiPi.enabled = 0;
     }
   else if (flag == 2)
@@ -85,12 +81,12 @@ mpiPi_MPI_Pcontrol (const int flag)
   else if (flag == 3)
     {
       mpiPi_generateReport (mpiPi_style_verbose);
-      mpiPi_GETTIME (&mpiPi.startTime);
+      mpiPi_stats_mt_timer_start(&mpiPi.task_stats);
     }
   else if (flag == 4)
     {
       mpiPi_generateReport (mpiPi_style_concise);
-      mpiPi_GETTIME (&mpiPi.startTime);
+      mpiPi_stats_mt_timer_start(&mpiPi.task_stats);
     }
   else
     {
@@ -100,7 +96,7 @@ mpiPi_MPI_Pcontrol (const int flag)
 
       mpiPi.enabled = 1;
       mpiPi.enabledCount++;
-      mpiPi_GETTIME (&mpiPi.startTime);
+      mpiPi_stats_mt_timer_start(&mpiPi.task_stats);
     }
 
   return MPI_SUCCESS;

--- a/pcontrol.c
+++ b/pcontrol.c
@@ -25,6 +25,20 @@ void
 mpiPi_reset_callsite_data ()
 {
   mpiPi_stats_mt_cs_reset(&mpiPi.task_stats);
+  /* Drop the content of the src ID cache so the old callsites won't appear in
+   * the callsites unless they are invoked again
+   */
+  if (NULL != callsite_src_id_cache) {
+      int ac, ndx;
+      callsite_stats_t **av;
+
+      h_drain(callsite_src_id_cache, &ac, (void ***)&av);
+      for (ndx = 0; ndx < ac; ndx++)
+        {
+          free(av[ndx]);
+        }
+      free(av);
+    }
 
   if (time (&mpiPi.start_timeofday) == (time_t) - 1)
     {

--- a/report.c
+++ b/report.c
@@ -816,7 +816,7 @@ print:
           if (mpiPi.coll_time_stats[x][y][z] == 0)
             goto done;
 
-          mpiPi_stats_thr_coll_binstrings(&mpiPi.task_stats, y, commbinbuf,
+          mpiPi_stats_mt_coll_binstrings(&mpiPi.task_stats, y, commbinbuf,
                                         z, databinbuf);
 
           fprintf (fp,
@@ -900,7 +900,7 @@ print:
           if (mpiPi.pt2pt_send_stats[x][y][z] == 0)
             goto done;
 
-          mpiPi_stats_thr_pt2pt_binstrings(&mpiPi.task_stats,
+          mpiPi_stats_mt_pt2pt_binstrings(&mpiPi.task_stats,
                                            y, commbinbuf,
                                            z, databinbuf);
 
@@ -1935,7 +1935,7 @@ mpiPi_coll_print_all_callsite_time_info (FILE * fp)
 
       task_stats->rank = mpiPi.rank;
 
-      mpiPi_stats_thr_cs_lookup(&mpiPi.task_stats,
+      mpiPi_stats_mt_cs_lookup(&mpiPi.task_stats,
                                task_stats, &task_lookup, &cs_buf,
                                MPIPI_CALLSITE_MIN2ZERO);
 
@@ -2057,7 +2057,7 @@ mpiPi_coll_print_concise_callsite_time_info (FILE * fp)
 
       /*  Search for task local entry for the current call site   */
       task_stats->rank = mpiPi.rank;
-      mpiPi_stats_thr_cs_lookup(&mpiPi.task_stats,
+      mpiPi_stats_mt_cs_lookup(&mpiPi.task_stats,
                                task_stats, &task_lookup, &cs_buf,
                                MPIPI_CALLSITE_MIN2MAX);
       tot_tasks = 0;
@@ -2172,7 +2172,7 @@ mpiPi_coll_print_concise_callsite_sent_info (FILE * fp)
 
       task_stats->rank = mpiPi.rank;
       /*  Search for task local entry for the current call site   */
-      mpiPi_stats_thr_cs_lookup(&mpiPi.task_stats,
+      mpiPi_stats_mt_cs_lookup(&mpiPi.task_stats,
                                task_stats, &task_lookup, &cs_buf,
                                MPIPI_CALLSITE_MIN2MAX);
       tot_tasks = 0;
@@ -2292,7 +2292,7 @@ mpiPi_coll_print_concise_callsite_io_info (FILE * fp)
 
       /*  Search for task local entry for the current call site   */
       task_stats->rank = mpiPi.rank;
-      mpiPi_stats_thr_cs_lookup(&mpiPi.task_stats,
+      mpiPi_stats_mt_cs_lookup(&mpiPi.task_stats,
                                task_stats, &task_lookup, &cs_buf,
                                MPIPI_CALLSITE_MIN2MAX);
       tot_tasks = 0;
@@ -2406,7 +2406,7 @@ mpiPi_coll_print_concise_callsite_rma_info (FILE * fp)
 
       /*  Search for task local entry for the current call site   */
       task_stats->rank = mpiPi.rank;
-      mpiPi_stats_thr_cs_lookup(&mpiPi.task_stats,
+      mpiPi_stats_mt_cs_lookup(&mpiPi.task_stats,
                                task_stats, &task_lookup, &cs_buf,
                                MPIPI_CALLSITE_MIN2MAX);
 
@@ -2531,7 +2531,7 @@ mpiPi_coll_print_all_callsite_sent_info (FILE * fp)
                           MPI_CHAR, mpiPi.collectorRank, mpiPi.comm);
 
               task_stats->rank = mpiPi.rank;
-              mpiPi_stats_thr_cs_lookup(&mpiPi.task_stats,
+              mpiPi_stats_mt_cs_lookup(&mpiPi.task_stats,
                                        task_stats, &task_lookup, &cs_buf,
                                        MPIPI_CALLSITE_MIN2ZERO);
 
@@ -2670,7 +2670,7 @@ mpiPi_coll_print_all_callsite_io_info (FILE * fp)
                           MPI_CHAR, mpiPi.collectorRank, mpiPi.comm);
 
               task_stats->rank = mpiPi.rank;
-              mpiPi_stats_thr_cs_lookup(&mpiPi.task_stats,
+              mpiPi_stats_mt_cs_lookup(&mpiPi.task_stats,
                                        task_stats, &task_lookup, &cs_buf,
                                        MPIPI_CALLSITE_MIN2ZERO);
 
@@ -2805,7 +2805,7 @@ mpiPi_coll_print_all_callsite_rma_info (FILE * fp)
                           MPI_CHAR, mpiPi.collectorRank, mpiPi.comm);
 
               task_stats->rank = mpiPi.rank;
-              mpiPi_stats_thr_cs_lookup(&mpiPi.task_stats,
+              mpiPi_stats_mt_cs_lookup(&mpiPi.task_stats,
                                        task_stats, &task_lookup, &cs_buf,
                                        MPIPI_CALLSITE_MIN2ZERO);
 

--- a/wrappers_special.c
+++ b/wrappers_special.c
@@ -42,16 +42,16 @@ _MPI_Init (int *argc, char ***argv)
 #if defined(Linux) && ! defined(ppc64)
   mpiPi.appFullName = getProcExeLink ();
   mpiPi_msg_debug ("appFullName is %s\n", mpiPi.appFullName);
-  mpiPi_init (GetBaseAppName (mpiPi.appFullName));
+  mpiPi_init (GetBaseAppName (mpiPi.appFullName), MPIPI_MODE_ST);
 #else
   if (argv != NULL && *argv != NULL && **argv != NULL)
     {
-      mpiPi_init (GetBaseAppName (**argv));
+      mpiPi_init (GetBaseAppName (**argv), MPIPI_MODE_ST);
       mpiPi.appFullName = strdup (**argv);
     }
   else
     {
-      mpiPi_init ("Unknown");
+      mpiPi_init ("Unknown", MPIPI_MODE_ST);
       mpiPi_msg_debug ("argv is NULL\n");
     }
 #endif
@@ -110,27 +110,31 @@ _MPI_Init_thread (int *argc, char ***argv, int required, int *provided)
 {
   int rc = 0;
   int enabledStatus;
+  mpiPi_thr_mode_t mode = MPIPI_MODE_ST;
 
   enabledStatus = mpiPi.enabled;
   mpiPi.enabled = 0;
 
   rc = PMPI_Init_thread (argc, argv, required, provided);
+  if (MPI_THREAD_MULTIPLE == *provided) {
+      mode = MPIPI_MODE_MT;
+  }
 
   mpiPi.enabled = enabledStatus;
 
 #if defined(Linux) && ! defined(ppc64)
   mpiPi.appFullName = getProcExeLink ();
   mpiPi_msg_debug ("appFullName is %s\n", mpiPi.appFullName);
-  mpiPi_init (GetBaseAppName (mpiPi.appFullName));
+  mpiPi_init (GetBaseAppName (mpiPi.appFullName), mode);
 #else
   if (argv != NULL && *argv != NULL && **argv != NULL)
     {
-      mpiPi_init (GetBaseAppName (**argv));
+      mpiPi_init (GetBaseAppName (**argv), mode);
       mpiPi.appFullName = strdup (**argv);
     }
   else
     {
-      mpiPi_init ("Unknown");
+      mpiPi_init ("Unknown", MPIPI_MODE_MT);
       mpiPi_msg_debug ("argv is NULL\n");
     }
 #endif


### PR DESCRIPTION
## Status
* This PR is based (and waiting) for #11 and #12
* **ready to merge**

## Details:
* As MPI implementation, Open MPI was used.
* The following simple application [[link](https://github.com/artpol84/poc/tree/master/MPI/MPI_mt)] was used to test the implementation. 
* It will be updated to increase the coverage.

### Test no. 1: Multi-threaded point-to-point
* **cmdline**: `mpirun -np 2 -x LD_PRELOAD ./mt_test1 -m -t 2 -n 1000 -v p2p-sb-rb`
  * `-m` enables MPI Thread multiple
  * `-t 2` defines 2 threads to use on each rank
  * `-n 1000` - number of sends/receives each thread is performing
  * `-v  p2p-sb-rb` - test type: each thread of rank=0 performs 1000 blocking sends (using integer thread id as the tag). rank=1 performs matching receives.

#### Results (mpiP/master)
```
---------------------------------------------------------------------------
@--- Aggregate Time (top twenty, descending, milliseconds) ----------------
---------------------------------------------------------------------------
Call                 Site       Time    App%    MPI%      Count    COV
Recv                    2       10.6     inf   71.18        876   0.00
Send                    1        4.3     inf   28.82        243   0.00
```
Number of Send and Recv invocations should be 2000 (1000 iteration * 2 threads),
App time is incorrectly calculated.
#### Results (mpiP/PR#13)
```
---------------------------------------------------------------------------
@--- Aggregate Time (top twenty, descending, milliseconds) ----------------
---------------------------------------------------------------------------
Call                 Site       Time    App%    MPI%      Count    COV
Recv                    2       78.2   71.26   54.53       2000   0.00
Send                    1       65.2   59.41   45.47       2000   0.00

```
The number of Send and Recv is correct, application % is not screwed.

