### PR TITLE
update to work with binutils-2.34

### DIFF
--- a/configure
+++ b/configure
@@ -5205,6 +5205,12 @@ $as_echo "#define HAVE_BFD_GET_SECTION_SIZE /**/" >>confdefs.h
 
 fi
 
+    ac_fn_c_check_decl "$LINENO" "bfd_get_section_vma" "ac_cv_have_decl_bfd_get_section_vma" "#include \"bfd.h\"
+"
+if test "x$ac_cv_have_decl_bfd_get_section_vma" = xyes; then :
+  $as_echo "#define HAVE_BFD_GET_SECTION_MACROS 1" >>confdefs.h
+
+fi
 
 else
   ENABLE_BFD=no SO_LOOKUP=no

--- a/configure.ac
+++ b/configure.ac
@@ -411,6 +411,7 @@ if test "x$ENABLE_BFD" = "xyes" ; then
   AC_CHECK_HEADER(bfd.h,
     AC_CHECK_LIB(bfd,bfd_openr, LIBS="$LIBS -lbfd", ENABLE_BFD=no, $BFD_AUX_LIBS)
     AC_CHECK_DECL(bfd_get_section_size, AC_DEFINE([HAVE_BFD_GET_SECTION_SIZE], [], [BFD get section size]), ,[#include "bfd.h"]) 
+    AC_CHECK_DECL(bfd_get_section_vma, AC_DEFINE(HAVE_BFD_GET_SECTION_MACROS), ,[#include "bfd.h"])
     , ENABLE_BFD=no SO_LOOKUP=no
   )
   AC_CHECK_TYPE(bfd_boolean, ,AC_DEFINE([HAVE_BFD_BOOLEAN], [], [BFD booleans]), [#include "bfd.h"])

--- a/mpiPconfig.h.in
+++ b/mpiPconfig.h.in
@@ -24,6 +24,9 @@
 /* BFD get section size */
 #undef HAVE_BFD_GET_SECTION_SIZE
 
+/* BFD macros available before version 2.34 */
+#undef HAVE_BFD_GET_SECTION_MACROS
+
 /* Have demangling */
 #undef HAVE_DEMANGLE_H
 

--- a/pc_lookup.c
+++ b/pc_lookup.c
@@ -146,12 +146,25 @@ find_address_in_section (abfd, section, data)
   local_pc = pc /*& (~0x10000000) */ ;
 #endif
 
+#if defined(HAVE_BFD_GET_SECTION_MACROS)
   if ((bfd_get_section_flags (abfd, section) & SEC_ALLOC) == 0)
   {
     mpiPi_msg_debug ("failed bfd_get_section_flags\n");
     return;
   }
+#else
+  if ((bfd_section_flags (section) & SEC_ALLOC) == 0)
+  {
+    mpiPi_msg_debug ("failed bfd_section_flags\n");
+    return;
+  }
+#endif
+
+#if defined(HAVE_BFD_GET_SECTION_MACROS)
   vma = bfd_get_section_vma (abfd, section);
+#else
+  vma = bfd_section_vma (section);
+#endif
 
   if (local_pc < vma)
   {
@@ -159,9 +172,15 @@ find_address_in_section (abfd, section, data)
       {
         sprintf_vma (addr_buf1, local_pc);
         sprintf_vma (addr_buf2, vma);
+#if defined(HAVE_BFD_GET_SECTION_MACROS)
         mpiPi_msg_debug
             ("failed bfd_get_section_vma: local_pc=%s  vma=%s\n",
              addr_buf1, addr_buf2);
+#else
+        mpiPi_msg_debug
+           ("failed bfd_section_vma: local_pc=%s  vma=%s\n",
+            addr_buf1, addr_buf2);
+#endif
       }
     return;
   }
@@ -169,13 +188,15 @@ find_address_in_section (abfd, section, data)
 /* The following define addresses binutils modifications between
  * version 2.15 and 2.15.96
 */
-#ifdef HAVE_BFD_GET_SECTION_SIZE
+#if defined(HAVE_BFD_GET_SECTION_SIZE)
   size = bfd_get_section_size (section);
-#else
+#elif defined(HAVE_BFD_GET_SECTION_MACROS)
   if (section->reloc_done)
     size = bfd_get_section_size_after_reloc (section);
   else
     size = bfd_get_section_size_before_reloc (section);
+#else
+  size = bfd_section_size(section);
 #endif
 
   if (local_pc >= vma + size)


### PR DESCRIPTION
binutils 2.34 removed a couple of functions that mpiP calls from pc_lookup.c,
or rather changed their names and signatures:
https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=fd3619828e94a24a92cddec42cbc0ab33352eeb4

autoconf now detects whether the pre-2.34 macros are available, and if so uses them;
otherwise, attempts to use the new function names from binutils 2.34