### PR TITLE
Clarify stack trace behavior

### DIFF
--- a/configure
+++ b/configure
@@ -664,6 +664,9 @@ DO_DEMANGLE
 USE_GETARG
 PC_LOOKUP_FILE
 USE_LIBDWARF
+MPIP_CALLSITE_STACK_DEPTH_MAX
+MPIP_INTERNAL_STACK_DEPTH
+MPIP_CALLSITE_REPORT_STACK_DEPTH_MAX
 ENABLE_FORTRAN_WEAK_SYMS
 ENABLE_FORTRAN_XLATE
 ENABLE_MPI_NONBLOCKINGCOLLECTIVES
@@ -758,6 +761,7 @@ enable_setjmp
 enable_fortranxlate
 enable_fortranweak
 enable_stackdepth
+enable_internal_stackdepth
 enable_maxargs
 enable_dwarf
 enable_getarg
@@ -1404,7 +1408,11 @@ Optional Features:
   --disable-fortranxlate  Disable translation of Fortran opaque objects.
   --enable-fortranweak    Generate weak symbols for additional Fortran symbol
                           name styles.
-  --enable-stackdepth     Specify maximum stacktrace depth (default is 8).
+  --enable-stackdepth     Specify maximum report stacktrace depth (default is
+                          8).
+  --enable-internal-stackdepth
+                          Specify number of internal stack frames (default is
+                          3).
   --enable-maxargs        Maximum number of command line arguments copied
                           (default is 32).
   --enable-dwarf          Use DWARF library for source lookup.
@@ -3104,10 +3112,30 @@ fi
 
 
 cat >>confdefs.h <<_ACEOF
-#define MPIP_CALLSITE_STACK_DEPTH_MAX $STACKDEPTH
+#define MPIP_CALLSITE_REPORT_STACK_DEPTH_MAX $STACKDEPTH
 _ACEOF
 
-#AC_SUBST(MPIP_CALLSITE_STACK_DEPTH_MAX)
+
+
+# Check whether --enable-internal-stackdepth was given.
+if test "${enable_internal_stackdepth+set}" = set; then :
+  enableval=$enable_internal_stackdepth; MPIP_INTERNAL_STACK_DEPTH=$enableval;
+    echo "Internal stacktrace depth is $MPIP_INTERNAL_STACK_DEPTH"
+else
+  MPIP_INTERNAL_STACK_DEPTH=3
+fi
+
+
+cat >>confdefs.h <<_ACEOF
+#define MPIP_INTERNAL_STACK_DEPTH $MPIP_INTERNAL_STACK_DEPTH
+_ACEOF
+
+
+
+
+$as_echo "#define MPIP_CALLSITE_STACK_DEPTH_MAX (MPIP_CALLSITE_REPORT_STACK_DEPTH_MAX + MPIP_INTERNAL_STACK_DEPTH)" >>confdefs.h
+
+
 
 # Check whether --enable-maxargs was given.
 if test "${enable_maxargs+set}" = set; then :

--- a/configure.ac
+++ b/configure.ac
@@ -289,13 +289,25 @@ AC_SUBST(ENABLE_FORTRAN_WEAK_SYMS)
 
 
 AC_ARG_ENABLE(stackdepth,
-	AS_HELP_STRING([--enable-stackdepth], [Specify maximum stacktrace depth (default is 8).]),
+	AS_HELP_STRING([--enable-stackdepth], [Specify maximum report stacktrace depth (default is 8).]),
 	STACKDEPTH=$enableval; 
     echo "Maximum stacktrace depth is $STACKDEPTH",
 	STACKDEPTH=8,
 )
-AC_DEFINE_UNQUOTED([MPIP_CALLSITE_STACK_DEPTH_MAX], [$STACKDEPTH], [Depth of the callsite])
-#AC_SUBST(MPIP_CALLSITE_STACK_DEPTH_MAX)
+AC_DEFINE_UNQUOTED([MPIP_CALLSITE_REPORT_STACK_DEPTH_MAX], [$STACKDEPTH], [Stack depth of callsites in report])
+AC_SUBST(MPIP_CALLSITE_REPORT_STACK_DEPTH_MAX)
+
+AC_ARG_ENABLE(internal-stackdepth,
+	AS_HELP_STRING([--enable-internal-stackdepth], [Specify number of internal stack frames (default is 3).]),
+	MPIP_INTERNAL_STACK_DEPTH=$enableval; 
+    echo "Internal stacktrace depth is $MPIP_INTERNAL_STACK_DEPTH",
+	MPIP_INTERNAL_STACK_DEPTH=3,
+)
+AC_DEFINE_UNQUOTED([MPIP_INTERNAL_STACK_DEPTH], [$MPIP_INTERNAL_STACK_DEPTH], [Number of internal stack frames])
+AC_SUBST(MPIP_INTERNAL_STACK_DEPTH)
+
+AC_DEFINE([MPIP_CALLSITE_STACK_DEPTH_MAX], [(MPIP_CALLSITE_REPORT_STACK_DEPTH_MAX + MPIP_INTERNAL_STACK_DEPTH)], [Recorded stack depth of callsites])
+AC_SUBST(MPIP_CALLSITE_STACK_DEPTH_MAX)
 
 AC_ARG_ENABLE(maxargs,
     AS_HELP_STRING(--enable-maxargs,Maximum number of command line arguments copied (default is 32).),

--- a/make-wrappers.py
+++ b/make-wrappers.py
@@ -1516,7 +1516,7 @@ def GenerateWrappers():
     print("-----*----- Generating profiling wrappers")
     cwd = os.getcwd()
     os.chdir(cwd)
-    sname = cwd + "/wrappers.c"
+    sname = cwd + "/mpiP-wrappers.c"
     g = open(sname, "w")
     olist = StandardFileHeader(sname)
 

--- a/make-wrappers.py
+++ b/make-wrappers.py
@@ -1064,7 +1064,7 @@ def CreateWrapper(funct, olist):
     olist.append("mpiPi_GETTIME (&start);\n" )
 
     # capture call stack
-    olist.append("if ( mpiPi.stackDepth > 0 ) mpiPi_RecordTraceBack((*base_jbuf), call_stack, MPIP_CALLSITE_STACK_DEPTH);\n"  )
+    olist.append("if ( mpiPi.reportStackDepth > 0 ) mpiPi_RecordTraceBack((*base_jbuf), call_stack, mpiPi.fullStackDepth);\n"  )
 
     # end of enabled check
     olist.append("}\n\n")

--- a/mpiP-stats.c
+++ b/mpiP-stats.c
@@ -80,7 +80,7 @@ _thrd_pc_hashkey (const void *p)
   int i;
   callsite_stats_t *csp = (callsite_stats_t *) p;
   MPIP_CALLSITE_STATS_COOKIE_ASSERT (csp);
-  for (i = 0; i < MPIP_CALLSITE_STACK_DEPTH; i++)
+  for (i = 0; i < mpiPi.fullStackDepth; i++)
     {
       res ^= (unsigned) (long) csp->pc[i];
     }
@@ -100,7 +100,7 @@ trd_pc_comparator (const void *p1, const void *p2)
   express (op);
   express (rank);
 
-  for (i = 0; i < MPIP_CALLSITE_STACK_DEPTH; i++)
+  for (i = 0; i < mpiPi.fullStackDepth; i++)
     {
       express (pc[i]);
     }
@@ -208,7 +208,7 @@ mpiPi_stats_thr_cs_upd (mpiPi_thread_stat_t *stat,
   key.op = op;
   key.rank = rank;
   key.cookie = MPIP_CALLSITE_STATS_COOKIE;
-  for (i = 0; i < MPIP_CALLSITE_STACK_DEPTH; i++)
+  for (i = 0; i < mpiPi.fullStackDepth; i++)
     {
       key.pc[i] = pc[i];
     }
@@ -289,12 +289,6 @@ void mpiPi_stats_thr_cs_merge(mpiPi_thread_stat_t *dst,
   for(i=0; i<ac; i++)
     {
       callsite_stats_t *csp_src = av[i], *csp_dst;
-
-      /* update file/line in p if need */
-      if( NULL == csp_src->filename || NULL == csp_src->functname )
-        {
-          mpiPi_query_src (csp_src);
-        }
 
       /* Search for the callsite and create a new record if needed */
       if (NULL == h_search (dst->cs_stats, csp_src, (void **) &csp_dst))

--- a/mpiPconfig.h.in
+++ b/mpiPconfig.h.in
@@ -75,7 +75,13 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
 
-/* Depth of the callsite */
+/* Stack depth of callsites in report */
+#undef MPIP_CALLSITE_REPORT_STACK_DEPTH_MAX
+
+/* Internal stack frames */
+#undef MPIP_INTERNAL_STACK_DEPTH
+
+/* Recorded stack depth of callsites */
 #undef MPIP_CALLSITE_STACK_DEPTH_MAX
 
 /* MPI check time */

--- a/mpiPi.c
+++ b/mpiPi.c
@@ -126,15 +126,20 @@ mpiPi_init (char *appName, mpiPi_thr_mode_t thr_mode)
   if (DEFAULT_REPORT_FORMAT == mpiPi_style_concise)
     {
       mpiPi.report_style = mpiPi_style_concise;
-      mpiPi.stackDepth = 0;
+      mpiPi.reportStackDepth = 0;
       mpiPi.print_callsite_detail = 0;
     }
   else // verbose default
     {
       mpiPi.report_style = mpiPi_style_verbose;
-      mpiPi.stackDepth = 1;
+      mpiPi.reportStackDepth = 1;
       mpiPi.print_callsite_detail = 1;
     }
+
+  mpiPi.internalStackDepth = MPIP_INTERNAL_STACK_DEPTH;
+  mpiPi.fullStackDepth = mpiPi.reportStackDepth + mpiPi.internalStackDepth;
+  if ( mpiPi.fullStackDepth > MPIP_CALLSITE_STACK_DEPTH_MAX )
+      mpiPi.fullStackDepth = MPIP_CALLSITE_STACK_DEPTH_MAX;
 
 #ifdef COLLECTIVE_REPORT_DEFAULT
   mpiPi.collective_report = 1;
@@ -747,7 +752,7 @@ mpiPi_generateReport (int report_style)
 
   mpiPi_GETTIME (&timer_start);
   mergeResult = mpiPi_mergeResults ();
-  if (mergeResult == 1 && mpiPi.stackDepth == 0)
+  if (mergeResult == 1 && mpiPi.reportStackDepth == 0)
     mergeResult = mpiPi_insert_MPI_records ();
   if (mergeResult == 1)
     mergeResult = mpiPi_mergeCollectiveStats ();

--- a/mpiPi.h
+++ b/mpiPi.h
@@ -47,7 +47,6 @@
 
 #define MPIP_HELP_LIST PACKAGE_BUGREPORT
 
-#define MPIP_CALLSITE_STACK_DEPTH (mpiPi.stackDepth)
 #define MPIP_CALLSITE_STATS_COOKIE 518641
 #define MPIP_CALLSITE_STATS_COOKIE_ASSERT(f) {assert(MPIP_CALLSITE_STATS_COOKIE==((f)->cookie));}
 
@@ -174,7 +173,9 @@ typedef struct _mpiPi_t
 
   mpiPi_lookup_t *lookup;
 
-  int stackDepth;
+  int reportStackDepth;
+  int internalStackDepth;
+  int fullStackDepth;
   double reportPrintThreshold;
   int baseNames;
   MPIP_REPORT_FORMAT_TYPE reportFormat;

--- a/report.c
+++ b/report.c
@@ -591,8 +591,8 @@ mpiPi_print_callsites (FILE * fp)
            (frames_printed < mpiPi.reportStackDepth) && (av[i]->filename[j] != NULL) &&
            stack_continue_flag == 1; j++)
         {
-            //  May encounter multiple "wrappers.c" filename frames
-            if ( strcmp(av[i]->filename[j], "wrappers.c") == 0 )
+            //  May encounter multiple "mpiP-wrappers.c" filename frames
+            if ( strcmp(av[i]->filename[j], "mpiP-wrappers.c") == 0 )
                 continue;
 
             if ( NULL == display_op)

--- a/report.c
+++ b/report.c
@@ -554,7 +554,7 @@ mpiPi_print_callsites (FILE * fp)
   char addr_buf[24];
 
   /*  If stack depth is 0, call sites are really just MPI calls */
-  if (mpiPi.stackDepth == 0)
+  if (mpiPi.reportStackDepth == 0)
     return;
 
   h_gather_data (callsite_src_id_cache, &ac, (void ***) &av);
@@ -567,7 +567,7 @@ mpiPi_print_callsites (FILE * fp)
     {
       int j, currlen;
       for (j = 0;
-           (j < MPIP_CALLSITE_STACK_DEPTH) && (av[i]->filename[j] != NULL);
+           (j < mpiPi.fullStackDepth) && (av[i]->filename[j] != NULL);
            j++)
         {
           currlen = strlen (av[i]->filename[j]);
@@ -584,43 +584,53 @@ mpiPi_print_callsites (FILE * fp)
   for (i = 0; i < ac; i++)
     {
       int j;
+      char * display_op = NULL;
+      int frames_printed = 0;
+
       for (j = 0, stack_continue_flag = 1;
-           (j < MPIP_CALLSITE_STACK_DEPTH) && (av[i]->filename[j] != NULL) &&
+           (frames_printed < mpiPi.reportStackDepth) && (av[i]->filename[j] != NULL) &&
            stack_continue_flag == 1; j++)
         {
+            //  May encounter multiple "wrappers.c" filename frames
+            if ( strcmp(av[i]->filename[j], "wrappers.c") == 0 )
+                continue;
+
+            if ( NULL == display_op)
+                display_op = &(mpiPi.lookup[av[i]->op - mpiPi_BASE].name[4]);
+
+
           if (av[i]->line[j] == 0 &&
               (strcmp (av[i]->filename[j], "[unknown]") == 0 ||
                strcmp (av[i]->functname[j], "[unknown]") == 0))
             {
               fprintf (fp, "%3d %3d %-*s %-*s %s\n",
                        av[i]->id,
-                       j,
+                       frames_printed,
                        fileLenMax + 6,
                        mpiP_format_address (av[i]->pc[j], addr_buf),
                        funcLenMax,
                        av[i]->functname[j],
-                       (j ==
-                        0) ? &(mpiPi.lookup[av[i]->op -
-                             mpiPi_BASE].name[4]) : "");
+                       display_op);
             }
           else
             {
               fprintf (fp, "%3d %3d %-*s %5d %-*s %s\n",
                        av[i]->id,
-                       j,
+                       frames_printed,
                        fileLenMax,
                        av[i]->filename[j], av[i]->line[j],
                        funcLenMax,
                        av[i]->functname[j],
-                       (j ==
-                        0) ? &(mpiPi.lookup[av[i]->op -
-                             mpiPi_BASE].name[4]) : "");
+                       display_op);
             }
           /*  Do not bother printing stack frames above main   */
           if (strcmp (av[i]->functname[j], "main") == 0
               || strcmp (av[i]->functname[j], ".main") == 0
               || strcmp (av[i]->functname[j], "MAIN__") == 0)
             stack_continue_flag = 0;
+
+          display_op = "";
+          ++frames_printed;
         }
     }
   free (av);
@@ -633,7 +643,7 @@ mpiPi_print_top_time_sites (FILE * fp)
   callsite_stats_t **av;
   double timeCOV;
 
-  if (mpiPi.stackDepth > 0)
+  if (mpiPi.reportStackDepth > 0)
     h_gather_data (mpiPi.global_callsite_stats_agg, &ac, (void ***) &av);
   else
     h_gather_data (mpiPi.global_MPI_stats_agg, &ac, (void ***) &av);
@@ -707,7 +717,7 @@ mpiPi_print_top_sent_sites (FILE * fp)
 
   if (mpiPi.global_mpi_size > 0)
     {
-      if (mpiPi.stackDepth > 0)
+      if (mpiPi.reportStackDepth > 0)
         h_gather_data (mpiPi.global_callsite_stats_agg, &ac, (void ***) &av);
       else
         h_gather_data (mpiPi.global_MPI_stats_agg, &ac, (void ***) &av);
@@ -929,7 +939,7 @@ mpiPi_print_top_io_sites (FILE * fp)
    *  */
   if (mpiPi.global_mpi_io > 0)
     {
-      if (mpiPi.stackDepth > 0)
+      if (mpiPi.reportStackDepth > 0)
         h_gather_data (mpiPi.global_callsite_stats_agg, &ac, (void ***) &av);
       else
         h_gather_data (mpiPi.global_MPI_stats_agg, &ac, (void ***) &av);
@@ -973,7 +983,7 @@ mpiPi_print_top_rma_sites (FILE * fp)
    *  */
   if (mpiPi.global_mpi_rma > 0)
     {
-      if (mpiPi.stackDepth > 0)
+      if (mpiPi.reportStackDepth > 0)
         h_gather_data (mpiPi.global_callsite_stats_agg, &ac, (void ***) &av);
       else
         h_gather_data (mpiPi.global_MPI_stats_agg, &ac, (void ***) &av);

--- a/util.c
+++ b/util.c
@@ -125,43 +125,45 @@ mpiPi_getenv ()
 
             case 'k':
               {
-                mpiPi.stackDepth = atoi (optarg);
-                if (mpiPi.stackDepth < 0)
+                mpiPi.reportStackDepth = atoi (optarg);
+                if (mpiPi.reportStackDepth < 0)
                   {
                     if (mpiPi.rank == 0)
                       mpiPi_msg_warn
                           ("-k stackdepth invalid %d. Using 0.\n",
-                           mpiPi.stackDepth);
-                    mpiPi.stackDepth = 0;
+                           mpiPi.reportStackDepth);
+                    mpiPi.reportStackDepth = 0;
                     mpiPi.print_callsite_detail = 0;
                   }
-                if (mpiPi.stackDepth > MPIP_CALLSITE_STACK_DEPTH_MAX)
+                if (mpiPi.reportStackDepth > MPIP_CALLSITE_REPORT_STACK_DEPTH_MAX)
                   {
                     if (mpiPi.rank == 0)
                       mpiPi_msg_warn
                           ("stackdepth of %d too large. Using %d.\n",
-                           mpiPi.stackDepth, MPIP_CALLSITE_STACK_DEPTH_MAX);
-                    mpiPi.stackDepth = MPIP_CALLSITE_STACK_DEPTH_MAX;
+                           mpiPi.reportStackDepth, MPIP_CALLSITE_REPORT_STACK_DEPTH_MAX);
+                    mpiPi.reportStackDepth = MPIP_CALLSITE_REPORT_STACK_DEPTH_MAX;
                   }
-                else if (mpiPi.stackDepth > 4)
+                else if (mpiPi.reportStackDepth > 4)
                   {
                     if (mpiPi.rank == 0)
                       mpiPi_msg_warn
                           ("stackdepth of %d is large. Consider making it smaller.\n",
-                           mpiPi.stackDepth);
+                           mpiPi.reportStackDepth);
                   }
 
                 //  If the stack depth is 0, we are accumulating data
                 //  for each MPI op (i.e. potentially multiple callsites),
                 //  resulting in data that would not be useful for calculating COV.
-                if (mpiPi.stackDepth == 0)
+                if (mpiPi.reportStackDepth == 0)
                   mpiPi.calcCOV = 0;
 
                 if (mpiPi.rank == 0)
                   mpiPi_msg
                       ("Set the callsite stack traceback depth to [%d].\n",
-                       mpiPi.stackDepth);
+                       mpiPi.reportStackDepth);
               }
+              mpiPi.fullStackDepth = mpiPi.reportStackDepth + mpiPi.internalStackDepth;
+
               break;
 
             case 't':


### PR DESCRIPTION
Create separate variables for number of stack frames to include in report, number of internal stack frames, and total stack frames to record.

Identify mpiP-wrappers file in call stack for consistent call site reporting.
