### PR TITLE
Fix bug: incorrect callsite stack traceback during .so file handling

### DIFF
--- a/mpiPi.h
+++ b/mpiPi.h
@@ -113,6 +113,7 @@ typedef struct SO_INFO
 {
   void *lvma;
   void *uvma;
+  size_t offset;
   char *fpath;
   bfd *bfd;
 } so_info_t;


### PR DESCRIPTION
Read the offset from /proc/<pid #>/maps and add it to PC to handle callsite stack traceback correctly for .so files