### PR TITLE
provide compatibility to new versions of bfd (>2.37)

### DIFF
--- a/pc_lookup.c
+++ b/pc_lookup.c
@@ -110,6 +110,10 @@ mpiPdemangle (const char *mangledSym)
 
 #endif
 
+/* To provide compatibility to modern versions of bfd (>2.37) */
+#ifndef PTR
+#define PTR void *
+#endif
 
 static void
 find_address_in_section (abfd, section, data)


### PR DESCRIPTION
`PTR` type has been removed in the recent versions of binutils (>2.37) , which leads to errors like, 
 `error: unknown type name ‘PTR’`  
during compilation of mpiP. This provides a fix for that issue while providing backward compatibility to older versions.